### PR TITLE
ADD support Altruist Urban esp32-c6 version, small fixes and refactors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode/
 .pio/
+.platformio/
 builds
 .DS_Store

--- a/OTA_Update.cpp
+++ b/OTA_Update.cpp
@@ -153,7 +153,13 @@ void twoStageOTAUpdate(device_status_t &deviceStatus) {
 #ifdef ALTRUIST_INSIDE
 	String fetch_name(F("/latest32c6ins_"));
 #else
+// define pins for I2C
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
 	String fetch_name(F("/latest32c3_"));
+#endif
+#if defined(CONFIG_IDF_TARGET_ESP32C6)
+	String fetch_name(F("/latest32c6_"));
+#endif
 #endif
 	if (cfg::use_beta) {
 		fetch_name += F("beta");

--- a/airrohr-firmware.ino
+++ b/airrohr-firmware.ino
@@ -72,7 +72,7 @@
 
 #include "./utils.h"
 #include "defines.h"
-#include "ext_def.h"
+//#include "ext_def.h"
 #include "webserver/html-content.h"
 #include <Robonomics.h>
 #include "sensors/sensor_factory.h"

--- a/config_manager/config_defaults.h
+++ b/config_manager/config_defaults.h
@@ -1,7 +1,6 @@
 #ifndef __CONFIG_DEFAULTS_H__
 #define __CONFIG_DEFAULTS_H__
 
-#include "../ext_def.h"
 #include "../defines.h"
 
 namespace cfg {

--- a/config_manager/config_helpers.h
+++ b/config_manager/config_helpers.h
@@ -4,7 +4,6 @@
 #include <Arduino.h>
 #include "airrohr-cfg.h"
 #include "defines.h"
-#include "ext_def.h"
 
 #define JSON_BUFFER_SIZE 2800
 #define FORMAT_SPIFFS_IF_FAILED true

--- a/defines.h
+++ b/defines.h
@@ -86,9 +86,46 @@ constexpr const unsigned long DURATION_BEFORE_FORCED_RESTART_MS = ONE_DAY_IN_MS 
 #endif
 
 #ifdef ALTRUIST_URBAN
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
 #define SDA_I2C_PIN 3
 #define SCL_I2C_PIN 0
 #endif
+#if defined(CONFIG_IDF_TARGET_ESP32C6)
+#define SDA_I2C_PIN 3
+#define SCL_I2C_PIN 2
+#endif
+#endif // ALTRUIST_URBAN
+
+// pin config MEMS microphone
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+#define I2S_PIN_BCLK     7
+#define I2S_PIN_WS       6
+#define I2S_PIN_DIN      8
+#define I2S_PIN_DOUT     -1
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+#define I2S_PIN_BCLK     10
+#define I2S_PIN_WS       1
+#define I2S_PIN_DIN      11
+#define I2S_PIN_DOUT     -1
+#elif defined(ARDUINO_ESP32_DEV)
+#define I2S_PIN_BCLK     18
+#define I2S_PIN_WS       23
+#define I2S_PIN_DIN      19
+#define I2S_PIN_DOUT     -1
+#else
+  #error Unsupported board selection.
+#endif //i2s pins
+
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+#define PM_SERIAL_RX 1
+#define PM_SERIAL_TX 10
+#endif
+#if defined(CONFIG_IDF_TARGET_ESP32C6)
+#define PM_SERIAL_RX 5
+#define PM_SERIAL_TX 4
+#endif
+
+
 
 // Definition GPIOs for Zero based Arduino Feather M0 LoRaWAN
 #if defined(ARDUINO_SAMD_ZERO) && defined(SERIAL_PORT_USBVIRTUAL)
@@ -162,5 +199,143 @@ constexpr const unsigned long DURATION_BEFORE_FORCED_RESTART_MS = ONE_DAY_IN_MS 
 #define CLIENT_ADDRESS 2
 #define SERVER_ADDRESS 100
 #endif
+
+// TRANSFER FROM ext_def.h
+// Language config
+#define CURRENT_LANG INTL_LANG
+
+// Wifi config
+const char WLANSSID[] PROGMEM = "Not Set";
+const char WLANPWD[] PROGMEM = "";
+#define LOCAL_HOSTNAME "altruist"
+#define WLANNOPWD 0
+
+// BasicAuth config
+const char WWW_USERNAME[] PROGMEM = "admin";
+const char WWW_PASSWORD[] PROGMEM = "";
+#define WWW_BASICAUTH_ENABLED 0
+
+// Sensor Wifi config (config mode)
+#define FS_SSID ""
+#define FS_PWD ""
+
+// Where to send the data?
+#define SEND2ROBONOMICS 1
+#define SSL_ROBONOMICS 0
+#define SSL_FSAPP 0
+#define SEND2MQTT 0
+#define SEND2INFLUX 0
+#define SEND2LORA 0
+#define SEND2CSV 0
+#define SEND2CUSTOM 0
+
+enum LoggerEntry {
+    LoggerRobonomics,
+    LoggerFSapp,
+    LoggerInflux,
+    LoggerCustom,
+    LoggerCount
+};
+
+struct LoggerConfig {
+    uint16_t destport;
+    uint16_t errors;
+#if defined(ESP8266)
+    BearSSL::Session* session;
+#else
+    void* session;
+#endif
+};
+
+// IMPORTANT: NO MORE CHANGES TO VARIABLE NAMES NEEDED FOR EXTERNAL APIS
+
+static const char HOST_FSAPP[] PROGMEM = "server.chillibits.com";
+static const char URL_FSAPP[] PROGMEM = "/data.php";
+#define PORT_FSAPP 80
+
+static const char FW_DOWNLOAD_HOST[] PROGMEM = "upd.sensors.robonomics.network";
+#define FW_DOWNLOAD_PORT 80
+
+static const char FW_2ND_LOADER_URL[] PROGMEM = "/loader-002.bin";
+
+static const char NTP_SERVER_1[] PROGMEM = "0.pool.ntp.org";
+static const char NTP_SERVER_2[] PROGMEM = "1.pool.ntp.org";
+
+// define own API
+static const char HOST_CUSTOM[] PROGMEM = "192.168.100.73";
+static const char URL_CUSTOM[] PROGMEM = "";
+#define PORT_CUSTOM 5000
+#define USER_CUSTOM ""
+#define PWD_CUSTOM ""
+#define SSL_CUSTOM 0
+
+
+// Robonomics
+#include "./intl.h"
+static const char CURRENT_REG[] PROGMEM = "Global";
+// #define PORT_ROBONOMICS 31112
+#define PORT_ROBONOMICS 65
+#define ROBONOMICS_PUBLIC_NODE "polkadot.rpc.robonomics.network"
+
+// Donated by
+static const char DONATED_BY[] PROGMEM = "";
+
+// define own InfluxDB
+static const char HOST_INFLUX[] PROGMEM = "influx.server";
+static const char URL_INFLUX[] PROGMEM = "/write?db=sensorcommunity";
+#define PORT_INFLUX 8086
+#define USER_INFLUX ""
+#define PWD_INFLUX ""
+static const char MEASUREMENT_NAME_INFLUX[] PROGMEM = "feinstaub";
+#define SSL_INFLUX 0
+
+// GPS, preferred Neo-6M
+#define GPS_READ 1
+#define GPS_API_PIN 9
+#define GPS_LAT "0.0"
+#define GPS_LON "0.0"
+#define GPS_COORDS "0.0,0.0"
+
+// Temp compensation
+#define TEMP_CORRECTION "0.0"
+
+// MHZ19 CO2 sensor
+#define MHZ19_READ 0
+
+// automatic firmware updates
+#define AUTO_UPDATE 1
+
+// use beta firmware
+#define USE_BETA 0
+
+// OLED Display SSD1306 connected?
+#define HAS_DISPLAY 0
+
+// OLED Display SH1106 connected?
+#define HAS_SH1106 0
+
+// OLED Display um 180° gedreht?
+#define HAS_FLIPPED_DISPLAY 0
+
+// LCD Display LCD1602 connected?
+#define HAS_LCD1602 0
+
+// LCD Display LCD1602 (0x27) connected?
+#define HAS_LCD1602_27 0
+
+// LCD Display LCD2004 connected?
+#define HAS_LCD2004 0
+
+// LCD Display LCD2004 (0x27) connected?
+#define HAS_LCD2004_27 0
+
+// Show wifi info on displays
+#define DISPLAY_WIFI_INFO 1
+
+// Show device info on displays
+#define DISPLAY_DEVICE_INFO 1
+
+// Set debug level for serial output?
+#define DEBUG 3
 
 #endif // __DEFINES_H__

--- a/ext_def.h
+++ b/ext_def.h
@@ -1,5 +1,6 @@
 #ifndef __EXT_DEF_H__
 #define __EXT_DEF_H__
+/*
 
 // Language config
 #define CURRENT_LANG INTL_LANG
@@ -103,8 +104,14 @@ static const char MEASUREMENT_NAME_INFLUX[] PROGMEM = "feinstaub";
 #define PM_RESTART D8
 
 // define pins for I2C
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
 #define I2C_PIN_SCL D4
 #define I2C_PIN_SDA D3
+#endif
+#if defined(CONFIG_IDF_TARGET_ESP32C6)
+#define I2C_PIN_SCL D2
+#define I2C_PIN_SDA D3
+#endif
 
 // define serial interface pins for GPS modules
 #define GPS_SERIAL_RX D5
@@ -118,7 +125,7 @@ static const char MEASUREMENT_NAME_INFLUX[] PROGMEM = "feinstaub";
 #define PPD_PIN_PM1 GPS_SERIAL_TX
 #define PPD_PIN_PM2 GPS_SERIAL_RX
 #endif
-
+*/
 
 //  === pin assignments for Arduino SAMD Zero board ===================================
 #if defined(ARDUINO_SAMD_ZERO)
@@ -132,13 +139,20 @@ static const char MEASUREMENT_NAME_INFLUX[] PROGMEM = "feinstaub";
 #endif
 #endif
 
+/*
 //  === pin assignments for dev kit board ===================================
 #ifdef ESP32
-#define ONEWIRE_PIN D32
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
 #define PM_SERIAL_RX 1
 #define PM_SERIAL_TX 10
-#define PIN_CS D13
 #define PM_RESTART 25
+#endif
+#if defined(CONFIG_IDF_TARGET_ESP32C6)
+#define PM_SERIAL_RX 5
+#define PM_SERIAL_TX 4
+#endif
+#define ONEWIRE_PIN D32
+#define PIN_CS D13
 
 #if defined(FLIP_I2C_PMSERIAL) // exchange the pins of the ports to use external i2c connector for gps
 #define I2C_PIN_SCL D23
@@ -157,6 +171,7 @@ static const char MEASUREMENT_NAME_INFLUX[] PROGMEM = "feinstaub";
 //#define RFM69_RST D2
 //#define RFM69_INT D4
 #endif
+*/
 
 //  === pin assignments for lolin_d32_pro board ===================================
 #if defined(ARDUINO_LOLIN_D32_PRO)
@@ -275,10 +290,10 @@ static const char MEASUREMENT_NAME_INFLUX[] PROGMEM = "feinstaub";
 #define DNMS_READ 0
 #define DNMS_API_PIN 15
 #define DNMS_CORRECTION "0.0"
+/*
 
 // Temp compensation
 #define TEMP_CORRECTION "0.0"
-
 // GPS, preferred Neo-6M
 #define GPS_READ 1
 #define GPS_API_PIN 9
@@ -324,5 +339,6 @@ static const char MEASUREMENT_NAME_INFLUX[] PROGMEM = "feinstaub";
 
 // Set debug level for serial output?
 #define DEBUG 3
+*/
 
 #endif // __EXT_DEF_H__

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,7 +10,8 @@
 
 [platformio]
 src_dir = .
-default_envs = esp32c6_inside_en
+build_dir = ./builds
+default_envs = esp32c6_inside_en, esp32c6_urban_en, esp32c3_en, esp32c3_ru
 ; default_envs = esp32c3_en
 
 ;  -DDEBUG_ESP_PORT=Serial
@@ -121,11 +122,26 @@ lib_deps = ${common.lib_deps_urban}
 extra_scripts = ${common.extra_scripts}
 board_build.partitions = custom_partitions.csv
 
+[env:esp32c6_urban_en]
+lang = EN
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/54.03.20/platform-espressif32.zip
+framework = arduino
+board = esp32-c6-devkitc-1
+build_flags = ${common.build_flags_esp32_release} '-DINTL_EN' '-DKIT_C' '-DARDUINO_USB_MODE=1' "-DARDUINO_USB_CDC_ON_BOOT=1" "-DALTRUIST_URBAN"
+lib_deps = ${common.lib_deps_inside}
+extra_scripts = ${common.extra_scripts}
+; board_build.partitions = custom_partitions.csv
+; src_filter =
+;   + <.>
+;   + <*>
+;   -<display/>
+board_build.partitions = inside_partitions.csv
+
 [env:esp32c6_inside_en]
 lang = EN
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/54.03.20/platform-espressif32.zip
 framework = arduino
-board = esp32-c6-devkitm-1
+board = esp32-c6-devkitc-1
 build_flags = ${common.build_flags_esp32_release} '-DINTL_EN' '-DKIT_C' '-DARDUINO_USB_MODE=1' "-DARDUINO_USB_CDC_ON_BOOT=1" "-DALTRUIST_INSIDE" "-DDISPLAY_3IN52"
 lib_deps = ${common.lib_deps_inside}
 extra_scripts = ${common.extra_scripts}

--- a/platformio_script.py
+++ b/platformio_script.py
@@ -20,9 +20,14 @@ def after_build(source, target, env):
     lang = config.get(sectionName, "lang")
     target_name = lang.lower()
     if "esp32c3" in sectionName:
+        print("Program has been built!", sectionName)
         firmaware_prefix_name = "latest32c3"
-    elif "esp32c6" in sectionName:
+    elif "esp32c6_inside" in sectionName:
+        print("Program has been built!", sectionName)
         firmaware_prefix_name = "latest32c6ins"
+    elif "esp32c6_urban" in sectionName:
+        print("Program has been built!", sectionName)
+        firmaware_prefix_name = "latest32c6urb"
     else:
         firmaware_prefix_name = "latest"
 

--- a/sensors/drivers/i2s_noise/soundsensor.cpp
+++ b/sensors/drivers/i2s_noise/soundsensor.cpp
@@ -21,6 +21,7 @@
 
 #include "soundsensor.h"
 #include "arduinoFFT.h"
+#include "../../../defines.h"
 
 const i2s_port_t I2S_PORT = I2S_NUM_0;
 
@@ -37,27 +38,12 @@ const i2s_config_t i2s_config = {
   .use_apll             = true
 };
 
-// pin config MEMS microphone
-#define TTGO_LORA32_V21
-#if defined(TTGO_LORA32_V21)
-// define IO pins TTGO LoRa32 V1 for I2S for MEMS microphone
 const i2s_pin_config_t pin_config = {
-  .bck_io_num   = 7, 
-  .ws_io_num    = 6,  
-  .data_out_num = -1,
-  .data_in_num  = 8 
+  .bck_io_num   = I2S_PIN_BCLK,
+  .ws_io_num    = I2S_PIN_WS,
+  .data_out_num = I2S_PIN_DOUT,
+  .data_in_num  = I2S_PIN_DIN
 };
-#elif defined(ARDUINO_ESP32_DEV)
-// define IO pins Sparkfun for I2S for MEMS microphone
-const i2s_pin_config_t pin_config = {
-  .bck_io_num   = 18,
-  .ws_io_num    = 23,
-  .data_out_num = I2S_PIN_NO_CHANGE,  // -1,
-  .data_in_num  = 19
-};
-#else
-  #error Unsupported board selection.
-#endif
 
 SoundSensor::SoundSensor() {
   _fft = new arduinoFFT(_real, _imag, SAMPLES, SAMPLES);

--- a/sensors/sds011_sensor.cpp
+++ b/sensors/sds011_sensor.cpp
@@ -1,6 +1,6 @@
 #include "sds011_sensor.h"
 #include "../utils.h"
-#include "../ext_def.h"
+#include "../defines.h"
 #include "sensor_names.h"
 
 #define serialSDS (Serial1)

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,26 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+in
+  pkgs.mkShell {
+    buildInputs = [
+      pkgs.platformio
+      pkgs.esptool
+      pkgs.python312Packages.pip
+      pkgs.python312Packages.zopfli
+      pkgs.python312Packages.wheel
+      pkgs.python312Packages.pip
+      pkgs.python312Packages.intelhex
+      pkgs.python312Packages.wheel
+      pkgs.python312Packages.pyyaml
+      pkgs.python312Packages.pygments
+      pkgs.python312Packages.mdurl
+      pkgs.python312Packages.markdown-it-py
+      pkgs.python312Packages.rich
+      pkgs.python312Packages.rich-click
+      # optional: needed as a programmer i.e. for esp32
+      # pkgs.avrdude
+    ];
+    shellHook = ''
+export PLATFORMIO_CORE_DIR=$PWD/.platformio
+'';
+}

--- a/utils.cpp
+++ b/utils.cpp
@@ -25,7 +25,7 @@
 #include "./intl.h"
 #include "./utils.h"
 #include "./defines.h"
-#include "./ext_def.h"
+//#include "./ext_def.h"
 #include <SPIFFS.h>
 
 String get_chipid() {

--- a/webserver/pages/wifi.cpp
+++ b/webserver/pages/wifi.cpp
@@ -57,10 +57,10 @@ void webserver_wifi(struct_wifiInfo* wifiInfo, uint8_t count_wifiInfo, String &p
 				continue;
 			}
 			// Print SSID and RSSI for each network found
-#if defined(ALTRUIST_INSIDE)
+#if defined(CONFIG_IDF_TARGET_ESP32C6)
 			page_content += wlan_ssid_to_table_row(wifiInfo[indices[i]].ssid, ((wifiInfo[indices[i]].encryptionType == WIFI_AUTH_OPEN) ? " " : "🔒"), wifiInfo[indices[i]].RSSI);
 #endif
-#if defined(ALTRUIST_URBAN)
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
 			page_content += wlan_ssid_to_table_row(wifiInfo[indices[i]].ssid, ((wifiInfo[indices[i]].encryptionType == WIFI_AUTH_OPEN) ? " " : u8"🔒"), wifiInfo[indices[i]].RSSI);
 #endif
 		}

--- a/wifi_manager.cpp
+++ b/wifi_manager.cpp
@@ -151,7 +151,7 @@ static WiFiEventId_t disconnectEventHandler;
 #endif
 
 void connectWifi(SensorWebServer &webserver) {
-#if defined(ALTRUIST_URBAN)
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
 	if (WiFi.getAutoConnect()) {
 		WiFi.setAutoConnect(false);
 	}


### PR DESCRIPTION
## Description

 - Changes to pins have been made to enable the firmware to work on the new Altruist Urban board based on the esp32c6
 - Moved parameters from ext_def.h to defines.h (ext_def.h is no longer used in the firmware build)
 - Added generation of latest32c6urb firmware files
 - Added env:esp32c6_urban_en configuration in platformio
 - Added nix-shell file from nixos builds 
 
**Test Configuration(s)**:

* Your OS and its version: NixOS 25.05 (Warbler) 
* What controller do you use: esp32-c6 wroom 1

## Checklist:

Please, check that

- [ ] you have commented the code, particularly in hard-to-understand areas
- [ ] you have made corresponding changes to the documentation
- [ ] your changes generate no new warnings
- [ ] you have checked my code and corrected any misspellings
