### PR TITLE
ota update

### DIFF
--- a/OTA_Update.cpp
+++ b/OTA_Update.cpp
@@ -12,141 +12,215 @@
  * OTAUpdate                                                     *
  *****************************************************************/
 
-static bool fwDownloadStream(WiFiClient& client, const String& url, Stream* ostream, device_status_t &deviceStatus) {
+static const char* const FW_HOSTS[] = { FW_DOWNLOAD_HOST, FW_DOWNLOAD_HOST_ALTERNATIVE };
+static constexpr int FW_HOST_COUNT = 2;
+static constexpr unsigned long FW_HOST_TIMEOUT_MS = 30000;  // 30s per host attempt
 
-	HTTPClient http;
-	int bytes_written = -1;
-
-	// work with 128kbit/s downlinks
-	http.setTimeout(60 * 1000);
+static String buildUserAgent() {
 	String agent(SOFTWARE_VERSION_STR);
-    String esp_chipid = get_chipid();
 	agent += ' ';
-	agent += esp_chipid;
+	agent += get_chipid();
 	agent += ' ';
 	agent += String(cfg::current_lang);
 	agent += ' ';
 	agent += String(CURRENT_LANG);
-	agent += ' ';
+	return agent;
+}
 
-	http.setUserAgent(agent);
-	http.setReuse(false);
+static bool fwDownloadStream(WiFiClient& client, const String& url, Stream* ostream, device_status_t &deviceStatus) {
 
-	debug_outln_info(F("HTTP GET: "), String(FPSTR(FW_DOWNLOAD_HOST)) + ':' + String(FW_DOWNLOAD_PORT) + url);
+	String agent = buildUserAgent();
 
-	if (http.begin(client, FPSTR(FW_DOWNLOAD_HOST), FW_DOWNLOAD_PORT, url)) {
-		int r = http.GET();
-		debug_outln_info(F("GET r: "), String(r));
-		deviceStatus.last_update_returncode = r;
-		if (r == HTTP_CODE_OK) {
-			bytes_written = http.writeToStream(ostream);
+	for (int h = 0; h < FW_HOST_COUNT; h++) {
+		HTTPClient http;
+		http.setTimeout(FW_HOST_TIMEOUT_MS);
+		http.setUserAgent(agent);
+		http.setReuse(false);
+
+		debug_outln_info(F("HTTP GET: "), String(FW_HOSTS[h]) + ':' + String(FW_DOWNLOAD_PORT) + url);
+
+		if (http.begin(client, FW_HOSTS[h], FW_DOWNLOAD_PORT, url)) {
+			int r = http.GET();
+			debug_outln_info(F("GET r: "), String(r));
+			deviceStatus.last_update_returncode = r;
+			if (r == HTTP_CODE_OK) {
+				int bytes_written = http.writeToStream(ostream);
+				http.end();
+				if (bytes_written > 0) return true;
+			} else {
+				http.end();
+			}
 		}
-		http.end();
+		debug_outln_info(F("Host failed, trying next..."));
 	}
-
-	if (bytes_written > 0)
-		return true;
 
 	return false;
 }
 
-bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status_t &deviceStatus) {
-    WiFiClient client;
-    HTTPClient http;
-    http.begin(client, FPSTR(FW_DOWNLOAD_HOST), FW_DOWNLOAD_PORT, url);
-    int httpCode = http.GET();
-    if (httpCode != HTTP_CODE_OK) {
-        debug_outln_info(F("Failed to download file, http code: "), httpCode);
-        http.end();
-        return false;
-    }
+bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status_t &deviceStatus)
+{
+    static constexpr unsigned long OTA_TOTAL_TIMEOUT_MS = 600000;  // 10 min total across all attempts
+    static constexpr int MAX_ATTEMPTS = FW_HOST_COUNT * 2;         // each host gets 2 tries
 
-    int contentLength = http.getSize();
-    if (contentLength <= 0) {
-        debug_outln_error(F("Content-Length not defined or invalid"));
-        http.end();
-        return false;
-    }
+    const unsigned long totalStartTime = millis();
+    String agent = buildUserAgent();
 
-    bool canBegin = Update.begin(contentLength);
-    if (!canBegin) {
-        debug_outln_error(F("Not enough space to begin OTA"));
-        http.end();
-        return false;
-    }
+    for (int attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+        int hostIdx = attempt % FW_HOST_COUNT;
+        const char* host = FW_HOSTS[hostIdx];
 
-    debug_outln_info(F("Begin OTA. This may take some time..."));
-
-    // WiFiClient *stream = http.getStreamPtr();
-    // size_t written = Update.writeStream(*stream);
-
-	WiFiClient stream = http.getStream();
-	const size_t bufferSize = 1024;
-	uint8_t buffer[bufferSize];
-	size_t written = 0;
-	int lastPercent = -1;
-
-	while (stream.connected() && written < contentLength) {
-		size_t available = stream.available();
-		if (available) {
-			size_t toRead = (available > bufferSize) ? bufferSize : available;
-			int bytesRead = stream.readBytes(buffer, toRead);
-
-			if (bytesRead > 0) {
-				if (Update.write(buffer, bytesRead) != bytesRead) {
-					debug_outln_error(F("Update.write() failed"));
-					http.end();
-					return false;
-				}
-
-				written += bytesRead;
-
-				// Update progress for display (every 1% for responsive display)
-				int percent = (written * 100) / contentLength;
-				if (percent != lastPercent) {
-					deviceStatus.ota_progress_percent = percent;
-					if (percent % 5 == 0) {
-						debug_outln_info(F("OTA Progress: "), percent);
-					}
-					lastPercent = percent;
-				}
-			}
-		}
-		delay(1);  // yield
-	}
-
-    if (written == contentLength) {
-        debug_outln_info(F("Written successfully: "), written);
-    } else {
-		debug_outln_info(F("Content length: "), contentLength);
-        debug_outln_info(F("Written only: "), written);
-    }
-
-    if (Update.end()) {
-        if (Update.isFinished()) {
-            debug_outln_info(F("Update successfully completed."));
-            String md5String = Update.md5String();
-            if (md5String.equalsIgnoreCase(expectedMD5)) {
-                debug_outln_info(F("MD5 verified successfully."));
-                http.end();
-                return true;
-            } else {
-                debug_outln_error(F("MD5 verification failed."));
-            }
-        } else {
-            debug_outln_error(F("Update not finished? Something went wrong!"));
+        if (millis() - totalStartTime > OTA_TOTAL_TIMEOUT_MS) {
+            debug_outln_error(F("OTA total timeout exceeded"));
+            return false;
         }
-    } else {
-        debug_outln_error(F("Error Occurred during update"));
+
+        if (WiFi.status() != WL_CONNECTED) {
+            debug_outln_error(F("WiFi not connected, aborting OTA"));
+            return false;
+        }
+
+        debug_outln_info(F("OTA attempt "), String(attempt + 1) + F(" host: ") + String(host));
+
+        WiFiClient client;
+        HTTPClient http;
+        http.setTimeout(FW_HOST_TIMEOUT_MS);
+        http.setUserAgent(agent);
+        http.setReuse(false);
+
+        if (!http.begin(client, host, FW_DOWNLOAD_PORT, url)) {
+            debug_outln_error(F("HTTP begin failed"));
+            continue;
+        }
+
+        int httpCode = http.GET();
+        if (httpCode != HTTP_CODE_OK) {
+            debug_outln_info(F("HTTP GET failed, code: "), String(httpCode));
+            http.end();
+            continue;
+        }
+
+        int contentLength = http.getSize();
+        if (contentLength <= 0) {
+            debug_outln_error(F("Invalid content length"));
+            http.end();
+            continue;
+        }
+
+        debug_outln_info(F("Content Length: "), String(contentLength));
+
+        if (!Update.begin(contentLength)) {
+            debug_outln_error(F("Not enough space for OTA"));
+            http.end();
+            return false;
+        }
+
+        WiFiClient& stream = http.getStream();
+        const size_t bufferSize = 1024;
+        uint8_t buffer[bufferSize];
+
+        size_t written = 0;
+        int lastPercent = -1;
+        unsigned long lastDataTime = millis();
+        bool download_ok = true;
+
+        deviceStatus.ota_progress_percent = 0;
+
+        while (written < (size_t)contentLength) {
+
+            if (millis() - totalStartTime > OTA_TOTAL_TIMEOUT_MS) {
+                debug_outln_error(F("OTA total timeout exceeded during download"));
+                Update.abort();
+                http.end();
+                return false;
+            }
+
+            if (WiFi.status() != WL_CONNECTED) {
+                debug_outln_error(F("WiFi disconnected during OTA"));
+                Update.abort();
+                http.end();
+                return false;
+            }
+
+            size_t available = stream.available();
+
+            if (available) {
+                size_t toRead = (available > bufferSize) ? bufferSize : available;
+                int bytesRead = stream.readBytes(buffer, toRead);
+
+                if (bytesRead > 0) {
+                    lastDataTime = millis();
+
+                    if (Update.write(buffer, bytesRead) != (size_t)bytesRead) {
+                        debug_outln_error(F("Update.write failed"));
+                        Update.abort();
+                        http.end();
+                        return false;
+                    }
+
+                    written += bytesRead;
+
+                    int percent = (written * 100) / contentLength;
+                    if (percent != lastPercent) {
+                        deviceStatus.ota_progress_percent = percent;
+                        if (percent % 5 == 0) {
+                            debug_outln_info(F("OTA Progress: "), String(percent) + F("%"));
+                        }
+                        lastPercent = percent;
+                    }
+                }
+            } else {
+                if (millis() - lastDataTime > FW_HOST_TIMEOUT_MS) {
+                    debug_outln_error(F("OTA stalled, switching host..."));
+                    download_ok = false;
+                    break;
+                }
+            }
+
+            delay(1);
+        }
+
+        if (!download_ok) {
+            Update.abort();
+            http.end();
+            deviceStatus.ota_progress_percent = 0;
+            continue;
+        }
+
+        debug_outln_info(F("Download complete. Written: "), String(written));
+
+        if (!Update.end()) {
+            debug_outln_error(F("Update.end failed"));
+            Update.abort();
+            http.end();
+            continue;
+        }
+
+        if (!Update.isFinished()) {
+            debug_outln_error(F("Update not finished properly"));
+            http.end();
+            continue;
+        }
+
+        String md5String = Update.md5String();
+        if (!md5String.equalsIgnoreCase(expectedMD5)) {
+            debug_outln_error(F("MD5 mismatch!"));
+            debug_outln_info(F("Expected: "), expectedMD5);
+            debug_outln_info(F("Actual: "), md5String);
+            http.end();
+            continue;
+        }
+
+        debug_outln_info(F("OTA successful and verified"));
+        http.end();
+        return true;
     }
 
-    http.end();
+    debug_outln_error(F("OTA failed after all attempts"));
     return false;
 }
 
-
-void twoStageOTAUpdate(device_status_t &deviceStatus) {
-	if (!cfg::auto_update) return;
+void twoStageOTAUpdate(device_status_t &deviceStatus, bool manual) {
+	if (!manual && !cfg::auto_update) return;
 
 	debug_outln_info(F("twoStageOTAUpdate"));
 	String lang_variant(cfg::current_lang);
@@ -202,7 +276,12 @@ void twoStageOTAUpdate(device_status_t &deviceStatus) {
 	if (downloadAndUpdate(fetch_name.c_str(), newFwmd5, deviceStatus)) {
         sensor_restart();
     }
-	// Download failed - hide OTA screen, user will see previous screen on next refresh
+
+	// Download failed — show error on display before returning to main screen
 	deviceStatus.ota_in_progress = false;
+	deviceStatus.ota_failed = true;
 	deviceStatus.ota_progress_percent = -1;
+	// Keep the failure screen visible for 15 seconds so the user can read it
+	vTaskDelay(pdMS_TO_TICKS(15000));
+	deviceStatus.ota_failed = false;
 }

--- a/OTA_Update.h
+++ b/OTA_Update.h
@@ -4,6 +4,6 @@
 #include "utils.h"
 
 bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status_t &deviceStatus);
-void twoStageOTAUpdate(device_status_t &deviceStatus);
+void twoStageOTAUpdate(device_status_t &deviceStatus, bool manual = false);
 
 #endif // __OTA_UPDATE_H__

--- a/airrohr-firmware.ino
+++ b/airrohr-firmware.ino
@@ -474,12 +474,18 @@ void sensorAndAPIWorker(void *pvParameters) {
 			activeAPIs[i]->updateDeviceStatus(deviceStatus);
 			
 			markCrashSection(CRASH_SECTION_IDLE);
-
-			if (msSince(deviceStatus.last_update_attempt) > PAUSE_BETWEEN_UPDATE_ATTEMPTS_MS) {
-				// OTA disabled - metrics code in development
-				twoStageOTAUpdate(deviceStatus);
-				deviceStatus.last_update_attempt = millis();
+				
+			bool manual_ota = deviceStatus.ota_update_requested;
+			if (manual_ota) {
+				deviceStatus.ota_update_requested = false;
 			}
+			if (WiFi.status() == WL_CONNECTED &&
+					(manual_ota || msSince(deviceStatus.last_update_attempt) > PAUSE_BETWEEN_UPDATE_ATTEMPTS_MS)) {
+
+					twoStageOTAUpdate(deviceStatus, manual_ota);
+					deviceStatus.last_update_attempt = millis();
+			}
+
 
 			#ifdef DEV
 			#if defined(ALTRUIST_INSIDE)
@@ -751,7 +757,6 @@ void setup(void) {
 	debug_outln_info(F("\nChipId: "), esp_chipid);
 	debug_outln_info(get_reset_reason_text());
 	// OTA runs from sensorAndAPIWorker (not here) so display can show "Updating" screen
-	// when loop() is already running
 
 	sensors_data["service_data"]["robonomics_address"] = robonomics.getSs58Address();
 	sensors_data["service_data"]["signal_strength"] = WiFi.RSSI();
@@ -781,7 +786,7 @@ void setup(void) {
     Serial.println();
 	#endif
 
-	deviceStatus.last_update_attempt = deviceStatus.time_point_device_start_ms = millis();
+	deviceStatus.last_update_attempt = deviceStatus.time_point_device_start_ms = millis() - PAUSE_BETWEEN_UPDATE_ATTEMPTS_MS;
 #if defined(USE_SD_CARD)
 	deviceStatus.sd_card_connected = sdCardLogger.begin();
 #endif

--- a/defines.h
+++ b/defines.h
@@ -3,7 +3,7 @@
 
 // increment on change
 #if defined(ALTRUIST_INSIDE)
-#define SOFTWARE_VERSION_STR "R-INS_2025-08"
+#define SOFTWARE_VERSION_STR "R-INS_2026-02"
 #define PM_SENSOR_NAME "Altruist Insight"
 #endif
 #if defined(ALTRUIST_URBAN)
@@ -312,6 +312,7 @@ static const char URL_FSAPP[] PROGMEM = "/data.php";
 #define PORT_FSAPP 80
 
 static const char FW_DOWNLOAD_HOST[] PROGMEM = "upd.sensors.robonomics.network";
+static const char FW_DOWNLOAD_HOST_ALTERNATIVE[] PROGMEM = "updru.sensors.robonomics.network";
 #define FW_DOWNLOAD_PORT 80
 
 static const char FW_2ND_LOADER_URL[] PROGMEM = "/loader-002.bin";
@@ -361,10 +362,12 @@ static const char MEASUREMENT_NAME_INFLUX[] PROGMEM = "feinstaub";
 #define MHZ19_READ 0
 
 // automatic firmware updates
-#ifdef ALTRUIST_INSIDE
-#define AUTO_UPDATE 0
+// Production builds: auto-update on
+// DEV builds: auto-update off
+#ifdef DEV
+	#define AUTO_UPDATE 0
 #else
-#define AUTO_UPDATE 1
+	#define AUTO_UPDATE 1
 #endif
 
 // use beta firmware

--- a/display/display_manager.cpp
+++ b/display/display_manager.cpp
@@ -324,8 +324,12 @@ void DisplayManager::process(button_pressed_t &btn_press) {
     // minute in the header changes right when the clock minute changes.
     // OTA screen: 15 sec interval for progress updates; partial/full handled in draw_complete.
     bool time_based_refresh = false;
-    if (deviceStatus.ota_in_progress) {
-        // First time: show immediately. Then refresh every 5 min.
+    static bool prev_ota_in_progress = false;
+    if (deviceStatus.ota_in_progress || deviceStatus.ota_failed) {
+        // Reset timer when transitioning from progress to failed so error screen shows immediately
+        if (prev_ota_in_progress && !deviceStatus.ota_in_progress) {
+            last_ota_display_ms = 0;
+        }
         bool ota_first_show = (last_ota_display_ms == 0);
         bool ota_interval_passed = (last_ota_display_ms > 0) && (msSince(last_ota_display_ms) > OTA_DISPLAY_REFRESH_INTERVAL);
         time_based_refresh = ota_first_show || ota_interval_passed;
@@ -342,6 +346,7 @@ void DisplayManager::process(button_pressed_t &btn_press) {
             next_main_refresh_ms = 0;
         }
     }
+    prev_ota_in_progress = deviceStatus.ota_in_progress;
 
     bool should_refresh = (last_refresh_time == (unsigned long)-DISPLAY_REFRESH_INTERVAL) || 
                           time_based_refresh || 
@@ -353,6 +358,12 @@ void DisplayManager::process(button_pressed_t &btn_press) {
         refresh_now = false;
         Paint_SelectImage(BlackImage);
         Paint_Clear(WHITE);
+        
+        if (deviceStatus.ota_failed) {
+            showOTAFailedPage(BlackImage);
+            last_ota_display_ms = millis();
+            goto draw_complete;
+        }
         
         if (deviceStatus.ota_in_progress) {
             showOTAUpdatePage(BlackImage, deviceStatus);
@@ -458,15 +469,15 @@ void DisplayManager::process(button_pressed_t &btn_press) {
         }
         
 draw_complete:
-        // Draw screen indicator (skip for OTA - full-screen message)
-        if (!deviceStatus.ota_in_progress) {
+        // Draw screen indicator (skip for OTA/failure - full-screen message)
+        if (!deviceStatus.ota_in_progress && !deviceStatus.ota_failed) {
             drawScreenIndicator(currentScreenID);
         }
         
         last_refresh_time = millis();
 
 
-        if (deviceStatus.ota_in_progress) {
+        if (deviceStatus.ota_in_progress || deviceStatus.ota_failed) {
             ota_display_refresh_count++;
             bool ota_do_full = (ota_display_refresh_count % OTA_FULL_REFRESH_EVERY_N == 0);
             epdDisplay(ota_do_full ? DisplayMode::FULL : DisplayMode::PARTIAL, BlackImage);
@@ -503,7 +514,7 @@ draw_complete:
             epdResetPeriodPosition(); // Reset period counter after full refresh
             debug_outln_verbose(F("[EPD] FULL refresh (watchdog/wake/main) pushed to panel"));
             epdDisplay(DisplayMode::FULL, BlackImage);
-        } else if (!deviceStatus.ota_in_progress) {
+        } else if (!deviceStatus.ota_in_progress && !deviceStatus.ota_failed) {
             // Pass current screen to showImageFast for adaptive update logic:
             // MAIN screen: 10 partial + 1 full
             // Other pages: 5 partial + 1 full

--- a/display/screens/ota_update.cpp
+++ b/display/screens/ota_update.cpp
@@ -7,16 +7,22 @@
 #include "../driver/EPD.h"
 #include "../../intl.h"
 #include "../paint_driver/fonts/fonts.h"
+#include "../icons/icons/40x40/robo_hw_logo_black_40x40.h"
 #include <stdio.h>
 
 void showOTAUpdatePage(UBYTE *BlackImage, const device_status_t &deviceStatus) {
     Paint_Clear(WHITE);
 
+    // Robonomics logo centered at top
+    int logo_x = (DISPLAY_WIDTH - 40) / 2;
+    int logo_y = 20;
+    Paint_DrawImage(robo_hw_logo_black_40x40, logo_x, logo_y, 40, 32);
+
     // Main message: "Updating firmware"
     const char* line1 = INTL_DISP_OTA_UPDATING;
     uint16_t line1_w = Paint_GetStringWidth_Display(line1, &Font24, &font_24_cyrillic, &font_24_ascii);
     uint16_t line1_x = (DISPLAY_WIDTH > line1_w) ? (DISPLAY_WIDTH - line1_w) / 2 : 0;
-    uint16_t line1_y = DISPLAY_HEIGHT / 2 - Font24.Height - Font16.Height * 2 - 16;
+    uint16_t line1_y = logo_y + 32 + 16;
     Paint_DrawString_Display(line1_x, line1_y, line1, &Font24, &font_24_cyrillic, &font_24_ascii, WHITE, BLACK);
 
     // Progress: "45%" when available
@@ -42,6 +48,29 @@ void showOTAUpdatePage(UBYTE *BlackImage, const device_status_t &deviceStatus) {
     uint16_t line3_x = (DISPLAY_WIDTH > line3_w) ? (DISPLAY_WIDTH - line3_w) / 2 : 0;
     uint16_t line4_y = line3_y + Font16.Height + 8;
     Paint_DrawString_Display(line3_x, line4_y, line3, &Font16, &font_16_cyrillic, &font_16_ascii, WHITE, BLACK);
+}
+
+void showOTAFailedPage(UBYTE *BlackImage) {
+    Paint_Clear(WHITE);
+
+    // Robonomics logo centered at top
+    int logo_x = (DISPLAY_WIDTH - 40) / 2;
+    int logo_y = 30;
+    Paint_DrawImage(robo_hw_logo_black_40x40, logo_x, logo_y, 40, 32);
+
+    // Main message: "Update failed"
+    const char* line1 = INTL_DISP_OTA_FAILED;
+    uint16_t line1_w = Paint_GetStringWidth_Display(line1, &Font24, &font_24_cyrillic, &font_24_ascii);
+    uint16_t line1_x = (DISPLAY_WIDTH > line1_w) ? (DISPLAY_WIDTH - line1_w) / 2 : 0;
+    uint16_t line1_y = logo_y + 32 + 20;
+    Paint_DrawString_Display(line1_x, line1_y, line1, &Font24, &font_24_cyrillic, &font_24_ascii, WHITE, BLACK);
+
+    // Sub message: "Will retry later"
+    const char* line2 = INTL_DISP_OTA_WILL_RETRY;
+    uint16_t line2_w = Paint_GetStringWidth_Display(line2, &Font16, &font_16_cyrillic, &font_16_ascii);
+    uint16_t line2_x = (DISPLAY_WIDTH > line2_w) ? (DISPLAY_WIDTH - line2_w) / 2 : 0;
+    uint16_t line2_y = line1_y + Font24.Height + 12;
+    Paint_DrawString_Display(line2_x, line2_y, line2, &Font16, &font_16_cyrillic, &font_16_ascii, WHITE, BLACK);
 }
 
 #endif

--- a/display/screens/ota_update.h
+++ b/display/screens/ota_update.h
@@ -7,6 +7,7 @@
 
 struct device_status_t;
 void showOTAUpdatePage(UBYTE *BlackImage, const device_status_t &deviceStatus);
+void showOTAFailedPage(UBYTE *BlackImage);
 
 #endif
 #endif

--- a/platformio_script.py
+++ b/platformio_script.py
@@ -2,8 +2,13 @@ Import("env")
 import configparser
 import hashlib
 import os
+import pathlib
 import shutil
 from base64 import b64decode
+
+# Touch html-content.h so PlatformIO recompiles files that include it.
+# This keeps __DATE__ fresh instead of stale from cached object files.
+pathlib.Path(os.path.join(env.subst("$PROJECT_DIR"), "webserver", "html-content.h")).touch()
 
 config = configparser.ConfigParser()
 config.read("platformio.ini")

--- a/translations/intl_en.h
+++ b/translations/intl_en.h
@@ -142,6 +142,11 @@ const char INTL_SAVE_AND_RESTART[] PROGMEM = "Save configuration and restart";
 const char INTL_SD_CONNECTED[] PROGMEM = "SD Card connected";
 const char INTL_FREE_RAM[] PROGMEM = "Free Memory (RAM)";
 const char INTL_LAST_OTA[] PROGMEM = "Last OTA";
+#define INTL_OTA_UPDATE "Firmware Update"
+const char INTL_OTA_CHECK_UPDATE[] PROGMEM = "Check for update";
+const char INTL_OTA_CURRENT_VERSION[] PROGMEM = "Current version";
+const char INTL_OTA_CHECK_REQUESTED[] PROGMEM = "Update check requested. The device will download and install the new firmware if available.";
+const char INTL_OTA_NO_WIFI[] PROGMEM = "WiFi is not connected. Cannot check for updates.";
 const char INTL_UPTIME[] PROGMEM = "Uptime";
 const char INTL_RESET_REASON[] PROGMEM = "Reset Reason";
 const char INTL_OTA_RETURN[] PROGMEM = "OTA Return";
@@ -220,6 +225,8 @@ const char INTL_SIGNAL_QUALITY[] PROGMEM = "signal quality";
 #define INTL_DISP_GOING_TO_SLEEP "Going to sleep..."
 #define INTL_DISP_OTA_UPDATING "Updating firmware"
 #define INTL_DISP_OTA_DO_NOT_DISCONNECT "Do not disconnect power"
+#define INTL_DISP_OTA_FAILED "Update failed"
+#define INTL_DISP_OTA_WILL_RETRY "Will retry later"
 #define INTL_DISP_WAITING_URBAN_ID "Waiting for Urban ID..."
 #define INTL_DISP_URBAN_IP "Urban IP:"
 #define INTL_DISP_INSIGHT_IP "Insight IP:"

--- a/translations/intl_ru.h
+++ b/translations/intl_ru.h
@@ -142,6 +142,11 @@ const char INTL_SAVE_AND_RESTART[] PROGMEM = "Сохранить и переза
 const char INTL_SD_CONNECTED[] PROGMEM = "SD карта подключена";
 const char INTL_FREE_RAM[] PROGMEM = "Свободно памяти (ОЗУ)";
 const char INTL_LAST_OTA[] PROGMEM = "Последний OTA";
+#define INTL_OTA_UPDATE "Обновление прошивки"
+const char INTL_OTA_CHECK_UPDATE[] PROGMEM = "Проверить обновление";
+const char INTL_OTA_CURRENT_VERSION[] PROGMEM = "Текущая версия";
+const char INTL_OTA_CHECK_REQUESTED[] PROGMEM = "Запрос на обновление отправлен. Устройство загрузит и установит новую прошивку, если она доступна.";
+const char INTL_OTA_NO_WIFI[] PROGMEM = "WiFi не подключен. Невозможно проверить обновления.";
 const char INTL_UPTIME[] PROGMEM = "Время работы";
 const char INTL_RESET_REASON[] PROGMEM = "Причина перезагрузки";
 const char INTL_OTA_RETURN[] PROGMEM = "OTA Ответ";
@@ -220,6 +225,8 @@ const char INTL_SIGNAL_QUALITY[] PROGMEM = "Качество";
 #define INTL_DISP_GOING_TO_SLEEP "Уход в сон..."
 #define INTL_DISP_OTA_UPDATING "Обновление прошивки"
 #define INTL_DISP_OTA_DO_NOT_DISCONNECT "Не отключайте питание"
+#define INTL_DISP_OTA_FAILED "Ошибка обновления"
+#define INTL_DISP_OTA_WILL_RETRY "Повтор позже"
 #define INTL_DISP_WAITING_URBAN_ID "Ожидание Urban ID..."
 #define INTL_DISP_URBAN_IP "IP Urban:"
 #define INTL_DISP_INSIGHT_IP "IP Insight:"

--- a/utils.h
+++ b/utils.h
@@ -82,7 +82,9 @@ struct device_status_t {
 	int last_update_returncode;
 	bool sd_card_connected = false;
 	bool ota_in_progress = false;  // When true, display shows "Updating firmware" screen
+	bool ota_failed = false;       // When true, display shows "Update failed" screen before returning
 	int ota_progress_percent = -1;  // 0-100 during download, -1 when not applicable
+	volatile bool ota_update_requested = false;  // Set by webserver to trigger manual OTA check
 	String ip_address;
 	std::map<std::string, api_status_t> apis_status;
 	std::vector<std::string> sensor_names;

--- a/webserver/html-content.h
+++ b/webserver/html-content.h
@@ -109,6 +109,7 @@ const char WEB_ROOT_PAGE_CONTENT[] PROGMEM = "<a class='b' href='/values'>{t}</a
 <a class='b' href='/status'>{s}</a>\
 <a class='b' href='https://sensors.social/' target='_blank' rel='noreferrer'>" INTL_ACTIVE_SENSORS_MAP "</a>\
 <a class='b' href='/config'>{conf}</a>\
+<a class='b' href='/ota'>" INTL_OTA_UPDATE "</a>\
 <a class='b danger' href='/removeConfig'>" INTL_CONFIGURATION_DELETE "</a>\
 <a class='b danger' href='/restart'>{restart}</a>\
 <a class='b' href='/debug'>{debug}</a>\

--- a/webserver/pages/config.cpp
+++ b/webserver/pages/config.cpp
@@ -48,8 +48,6 @@ void webserver_config_send_body_get(WebServer &server, String& page_content, boo
 		page_content += form_checkbox(cfgid, info, true, enabled);
 	};
 
-
-	// изменения в верстке
 	debug_outln_info(F("begin webserver_config_body_get ..."));
 	page_content += F("<form method='POST' action='/config' style='width:100%;'>\n"
   "<div class='tabs'>"

--- a/webserver/webserver.cpp
+++ b/webserver/webserver.cpp
@@ -2,6 +2,7 @@
 #include "pages/pages.h"
 #include "html-content.h"
 #include "script-js.h"
+#include "utils.h"
 #include "../config_manager/config_helpers.h"
 #include "robonomics-logo-common.h"
 
@@ -31,6 +32,7 @@ void SensorWebServer::setup() {
 	server.on(F("/data.json"), std::bind(&SensorWebServer::_webserver_data_json, this)); // x
 	server.on(F("/favicon.ico"), std::bind(&SensorWebServer::_webserver_favicon, this)); // x
 	server.on(F(STATIC_PREFIX), std::bind(&SensorWebServer::_webserver_static, this)); // x
+	server.on(F("/ota"), std::bind(&SensorWebServer::_webserver_ota, this));
 #ifdef ALTRUIST_INSIDE
 	server.on(F("/select_urban"), std::bind(&SensorWebServer::_webserver_select_urban, this));
 	server.on(F("/scan_urbans"), std::bind(&SensorWebServer::_webserver_scan_urbans, this));
@@ -432,6 +434,42 @@ void SensorWebServer::_webserver_select_urban() {
 	}
 }
 #endif
+
+void SensorWebServer::_webserver_ota() {
+	if (WiFi.status() != WL_CONNECTED) {
+		sendHttpRedirectGuest();
+		return;
+	}
+	if (!webserver_request_auth()) {
+		return;
+	}
+
+	RESERVE_STRING(page_content, LARGE_STR);
+	start_html_page(page_content, FPSTR(INTL_OTA_UPDATE));
+
+	if (server.method() == HTTP_POST) {
+		deviceStatus.ota_update_requested = true;
+		page_content += F("<div style='text-align:center;padding:30px;'>"
+			"<h3 style='color:#4CAF50;'>&#x2713; ");
+		page_content += FPSTR(INTL_OTA_CHECK_REQUESTED);
+		page_content += F("</h3></div>");
+	} else {
+		page_content += F("<div style='max-width:480px;margin:20px auto;padding:20px;'>");
+
+		page_content += F("<table>");
+		add_table_row_from_value(page_content, FPSTR(INTL_OTA_CURRENT_VERSION), String(SOFTWARE_VERSION_STR));
+		add_table_row_from_value(page_content, FPSTR(INTL_LAST_OTA),
+			delayToString(millis() - deviceStatus.last_update_attempt));
+		page_content += FPSTR(TABLE_TAG_CLOSE_BR);
+
+		page_content += F("<form method='POST' action='/ota' style='text-align:center;margin-top:20px;'>"
+			"<button type='submit' class='submit-btn'>");
+		page_content += FPSTR(INTL_OTA_CHECK_UPDATE);
+		page_content += F("</button></form></div>");
+	}
+
+	end_html_page(page_content);
+}
 
 void SensorWebServer::_webserver_config() {
     if (WiFi.status() != WL_CONNECTED) {

--- a/webserver/webserver.h
+++ b/webserver/webserver.h
@@ -56,6 +56,7 @@ private:
     void _webserver_favicon();
     void _webserver_static();
     void _webserver_not_found();
+    void _webserver_ota();
 
 #ifdef ALTRUIST_INSIDE
     void _webserver_select_urban();


### PR DESCRIPTION
## OTA Improvements

- **Auto-update default behavior**  
  Enabled in production builds, disabled in development (DEV) builds.

- **Manual OTA via Web UI**  
  Added a new `/ota` page that allows users to manually check for updates, even when auto-update is disabled.

- **Host failover**  
  Firmware download now attempts two servers (`FW_DOWNLOAD_HOST` and `FW_DOWNLOAD_HOST_ALTERNATIVE`), with a 30-second timeout per server and up to 4 attempts in total.

- **Failure feedback**  
  On update failure, the e-ink display shows an "Update failed" screen for 15 seconds before returning to the main screen.

- **Build date fix**  
  Updated the pre-build script to touch `html-content.h`, forcing `__DATE__` to recompile and preventing stale build dates in the Web UI.

- **Display updates**  
  OTA progress and failure screens now include the Robonomics logo.
