### PR TITLE
added 'publish to map' option + some clean up

### DIFF
--- a/airrohr-firmware.ino
+++ b/airrohr-firmware.ino
@@ -625,12 +625,14 @@ void setup(void) {
 	delay(300);
 	Serial.begin(115200);
 	delay(500);
+	#ifdef DEV
 	#if defined(ALTRUIST_INSIDE)
 	Serial.println(F("[INSIGHT] Start setup"));
 	#elif defined(ALTRUIST_URBAN)
 	Serial.println(F("[URBAN] Start setup"));
 	#endif
 	Serial.flush();
+	#endif
 	delay(200);
 
 	// If SET button pressed while turn on, reset the configuration

--- a/apis/api.h
+++ b/apis/api.h
@@ -8,8 +8,8 @@
 class API {
 protected:
     unsigned long timeout;  // Private variable for API timeout
-    unsigned long last_send_time;
-    time_t last_send_time_t;
+    unsigned long last_send_time = 0;
+    time_t last_send_time_t = 0;
     unsigned long count_sends = 0;
     unsigned long count_sends_success = 0;
     bool is_ok = true;
@@ -35,7 +35,7 @@ public:
 
     void updateDeviceStatus(device_status_t &deviceStatus) {
         debug_outln_info(F("Updating device status for "), api_name);
-        if (deviceStatus.apis_status.find("new_api") == deviceStatus.apis_status.end()) {
+        if (deviceStatus.apis_status.find(api_name) == deviceStatus.apis_status.end()) {
             debug_outln_info(F("Creating new API status"));
             deviceStatus.apis_status[api_name] = new_api_status;
             debug_outln_info(F("Created new API status"));

--- a/apis/helpers/message_formatter.cpp
+++ b/apis/helpers/message_formatter.cpp
@@ -1,9 +1,16 @@
 #include "message_formatter.h"
 #include "../../utils.h"
 #include "../../config_manager/config_defaults.h"
+#include "../../sensors/sensor_names.h"
+
+#define SCD4X_WARMUP_SEC 360
 
 void formatRobonomicsString(JsonDocument &data, String &datalog_data) {
     datalog_data = "";
+
+    bool has_scd4x = !data[SCD4X_SENSOR_NAME].isNull();
+    bool use_bme680_for_temp_hum = !has_scd4x || (millis() / 1000 < SCD4X_WARMUP_SEC);
+
     for (JsonPair sensor : data.as<JsonObject>())  {
         String sensor_name = sensor.key().c_str();
 
@@ -21,14 +28,20 @@ void formatRobonomicsString(JsonDocument &data, String &datalog_data) {
 				value = measurementData["value"].as<String>();
 			}
 
-            // Check data sharing preferences before including each measurement
+            bool is_bme680 = (sensor_name == BME680_SENSOR_NAME);
+            bool is_scd4x = (sensor_name == SCD4X_SENSOR_NAME);
+            bool skip_temp_hum = (is_bme680 && !use_bme680_for_temp_hum)
+                              || (is_scd4x && use_bme680_for_temp_hum);
+
             if (type == "P1" && cfg::share_pm) datalog_data += "p1:" + value + ",";
             else if (type == "P2" && cfg::share_pm) datalog_data += "p2:" + value + ",";
             else if (type == "noiseMax" && cfg::share_noise) datalog_data += "nm:" + value + ",";
             else if (type == "noiseAvg" && cfg::share_noise) datalog_data += "na:" + value + ",";
-            else if (type == "temperature" && cfg::share_temperature && datalog_data.indexOf("t:") == -1) datalog_data += "t:" + value + ",";
+            else if (type == "temperature" && cfg::share_temperature && datalog_data.indexOf("t:") == -1
+                     && !skip_temp_hum) datalog_data += "t:" + value + ",";
             else if (type == "pressure" && cfg::share_pressure) datalog_data += "p:" + value + ",";
-            else if (type == "humidity" && cfg::share_humidity && datalog_data.indexOf("h:") == -1) datalog_data += "h:" + value + ",";
+            else if (type == "humidity" && cfg::share_humidity && datalog_data.indexOf("h:") == -1
+                     && !skip_temp_hum) datalog_data += "h:" + value + ",";
             else if (type == "radiation") datalog_data += "gc:" + value + ",";
             else if (type == "co2" && cfg::share_co2) datalog_data += "co:" + value + ","; 
         }

--- a/apis/robonomics_datalog_api.cpp
+++ b/apis/robonomics_datalog_api.cpp
@@ -23,8 +23,18 @@ void RobonomicsDatalogAPI::setup() {
 void RobonomicsDatalogAPI::_send(JsonDocument &data) {
     String datalog_data;
     formatRobonomicsString(data, datalog_data);
-    debug_outln_info(F("Start sending datalog: "), datalog_data);
+    if (datalog_data.length() == 0) {
+        debug_outln_error(F("[Datalog] WARNING: data string is empty (all sharing disabled or no sensor data?)"));
+    }
+    debug_outln_verbose(F("[Datalog] Sending: "), datalog_data);
+    debug_outln_verbose(F("[Datalog] RWS owner: "), rws_owner);
+    debug_outln_verbose(F("[Datalog] Node: "), robonomics_public_node);
     const char* res = robonomics->sendRWSDatalogRecord(datalog_data.c_str(), rws_owner.c_str());
-	debug_outln_info(F("Datalog result: "), res);
     is_ok = (strcmp(res, "error") != 0);
+    if (is_ok) {
+        debug_outln_verbose(F("[Datalog] OK, result: "), res);
+    } else {
+        debug_outln_error(F("[Datalog] FAILED"));
+        debug_outln_verbose(F("[Datalog] Error response: "), res);
+    }
 }

--- a/apis/robonomics_http_api.cpp
+++ b/apis/robonomics_http_api.cpp
@@ -19,25 +19,41 @@ void RobonomicsHTTPAPI::_send(JsonDocument &data) {
     int num_of_host;
 	String data_to_send;
 	formatDataToSend(data_to_send, data);
-    debug_outln_info(F("robonomics: "), data_to_send);
+    debug_outln_verbose(F("[Map] Payload: "), data_to_send);
 	is_ok = false;
     num_of_host = chooseRobonomicsServer(false);
     if (num_of_host == 255) {
+        debug_outln_verbose(F("[Map] No regional server found, trying global..."));
         num_of_host = chooseRobonomicsServer(true);
     }
     if (num_of_host != 255) {
         POSTRequest(data_to_send, HOST_ROBONOMICS[num_of_host][0]);
+    } else {
+        debug_outln_error(F("[Map] FAILED: No server available (all hosts unreachable or returned errors)"));
     }
 }
 
 void RobonomicsHTTPAPI::formatDataToSend(String &data_to_send, JsonDocument &data) {
-	double last_value_GPS_lat;
-	double last_value_GPS_lon;
+	double last_value_GPS_lat = 0.0;
+	double last_value_GPS_lon = 0.0;
 	String datalog_data;
-	sscanf(cfg::coords_gps, "%lf,%lf", &last_value_GPS_lat, &last_value_GPS_lon);
+	int parsed = sscanf(cfg::coords_gps, "%lf,%lf", &last_value_GPS_lat, &last_value_GPS_lon);
+	if (parsed != 2 || (last_value_GPS_lat == 0.0 && last_value_GPS_lon == 0.0)) {
+		debug_outln_error(F("[Map] WARNING: GPS coordinates missing or invalid, raw value: "));
+		debug_outln_verbose(F("[Map] coords_gps = "), String(cfg::coords_gps));
+	} else {
+		debug_outln_verbose(F("[Map] GPS lat="), String(last_value_GPS_lat, 6));
+		debug_outln_verbose(F("[Map] GPS lon="), String(last_value_GPS_lon, 6));
+	}
 	formatRobonomicsString(data, datalog_data);
+	if (datalog_data.length() == 0) {
+		debug_outln_error(F("[Map] WARNING: sensor data string is empty (all sharing disabled or no sensor data?)"));
+	}
     String signature;
 	addTimeAndSign(datalog_data, signature, robonomics);
+	if (signature.length() == 0) {
+		debug_outln_error(F("[Map] WARNING: signature is empty (time not synced or signing failed)"));
+	}
     data_to_send = F("{\"robonomics_address\": \"");
     data_to_send += robonomics->getSs58Address();
     data_to_send += "\", \"donated_by\": \"";
@@ -61,7 +77,7 @@ void RobonomicsHTTPAPI::POSTRequest(const String& data, const char* host) {
     int result = 0;
     String s_Host(FPSTR(host));
 	String s_url(FPSTR(URL_ROBONOMICS));
-	debug_outln_info(F("Start POST to "), s_Host);
+	debug_outln_verbose(F("[Map] POST to "), s_Host + ":" + String(PORT_ROBONOMICS) + s_url);
     _http.setTimeout(20 * 1000);
 	_http.setUserAgent(SOFTWARE_VERSION + '/' + esp_chipid);
     _http.setReuse(false);
@@ -70,18 +86,21 @@ void RobonomicsHTTPAPI::POSTRequest(const String& data, const char* host) {
 		_http.addHeader(F("X-Sensor"), String(F(SENSOR_BASENAME)) + esp_chipid);
         result = _http.POST(data);
         if (result >= HTTP_CODE_OK && result <= HTTP_CODE_ALREADY_REPORTED) {
-			debug_outln_info(F("Succeeded - "), s_Host);
+			debug_outln_info(F("[Map] OK, POST succeeded -> "), s_Host);
 			is_ok = true;
 		} else if (result >= HTTP_CODE_BAD_REQUEST) {
-			debug_outln_info(F("Request failed with error: "), String(result));
-			debug_outln_info(F("Details:"), _http.getString());
+			debug_outln_error(F("[Map] FAILED: server returned HTTP error"));
+			debug_outln_verbose(F("[Map] HTTP code: "), String(result));
+			debug_outln_verbose(F("[Map] Response body: "), _http.getString());
 		} else {
-			debug_outln_info(F("Request failed with error: "), String(result));
-			debug_outln_info(F("Details:"), _http.getString());
+			debug_outln_error(F("[Map] FAILED: HTTP error (connection/timeout)"));
+			debug_outln_verbose(F("[Map] Error code: "), String(result));
+			debug_outln_verbose(F("[Map] Details: "), HTTPClient::errorToString(result));
 		}
         _http.end();
     } else {
-		debug_outln_info(F("Failed connecting to "), s_Host);
+		debug_outln_error(F("[Map] FAILED: could not begin HTTP connection"));
+		debug_outln_verbose(F("[Map] Host: "), s_Host);
 	}
 }
 
@@ -92,24 +111,18 @@ int RobonomicsHTTPAPI::chooseRobonomicsServer(bool onlyGlobal) {
 	int result = 0;
 	String s_url = FPSTR(URL_ROBONOMICS);
 	int numRobonomicsHosts = sizeof(HOST_ROBONOMICS) / sizeof(HOST_ROBONOMICS[0]);
-	debug_outln_info(F("Number of hosts - "), numRobonomicsHosts);
-	debug_outln_info(F("current reg - "), current_reg.c_str());
+	debug_outln_verbose(F("[Map] Selecting server: "), String(numRobonomicsHosts) + " hosts, region=" + current_reg.c_str() + (onlyGlobal ? " (global only)" : ""));
 
 	for (int i = 0; i < numRobonomicsHosts; i++) {
 		if (onlyGlobal) {
-			if (strcmp(HOST_ROBONOMICS[i][1], INTL_REGION_GLOBAL) == 0) {
-				String s_Host = FPSTR(HOST_ROBONOMICS[i][0]);
-			} else {
+			if (strcmp(HOST_ROBONOMICS[i][1], INTL_REGION_GLOBAL) != 0) {
 				continue;
 			}
-		} else if (strcmp(current_reg.c_str(), HOST_ROBONOMICS[i][1]) == 0) {
-			String s_Host = FPSTR(HOST_ROBONOMICS[i][0]);
-		} else {
-			debug_outln_info(F("Not suit region - "), FPSTR(HOST_ROBONOMICS[i][0]));
+		} else if (strcmp(current_reg.c_str(), HOST_ROBONOMICS[i][1]) != 0) {
 			continue;
 		}
 		String s_Host = FPSTR(HOST_ROBONOMICS[i][0]);
-		debug_outln_info(F("Start GET request - "), s_Host);
+		debug_outln_verbose(F("[Map] Trying GET "), s_Host + ":" + String(PORT_ROBONOMICS));
 
 		if (_http.begin(*_client, s_Host, PORT_ROBONOMICS, s_url)) {
 			const char * headerKeys[] = {"sensors-count", "on-server"} ;
@@ -118,18 +131,15 @@ int RobonomicsHTTPAPI::chooseRobonomicsServer(bool onlyGlobal) {
 			_http.addHeader("Sensor-id", robonomics->getSs58Address());
 
 			result = _http.GET();
-			debug_outln_info(F("Result code - "), result);
 
 			if (result >= HTTP_CODE_OK && result <= HTTP_CODE_ALREADY_REPORTED) {
-				debug_outln_info(F("Succeeded GET request - "), s_Host);
 				String header = _http.header("sensors-count");
 				String on_server = _http.header("on-server");
-				const char *num_of_sensors = header.c_str();
-				int num = atoi(num_of_sensors);
-				debug_outln_info(F("Amount of sensors - "), num_of_sensors);
-				debug_outln_info(F("Sensor on server - "), on_server);
+				int num = atoi(header.c_str());
+				debug_outln_verbose(F("[Map] OK from "), s_Host + " sensors=" + header + " on_server=" + on_server);
 				if (on_server == "True") {
 					num_of_robonomics_host = i;
+					_http.end();
 					break;
 				}
 				if (num < min_sensors) {
@@ -137,19 +147,22 @@ int RobonomicsHTTPAPI::chooseRobonomicsServer(bool onlyGlobal) {
 					num_of_robonomics_host = i;
 				}
 			} else if (result >= HTTP_CODE_BAD_REQUEST) {
-				debug_outln_info(F("Request failed with error: "), String(result));
-				debug_outln_info(F("Details:"), _http.getString());
+				debug_outln_verbose(F("[Map] Server error from "), s_Host + " HTTP " + String(result));
+				debug_outln_verbose(F("[Map] Response: "), _http.getString());
+			} else {
+				debug_outln_verbose(F("[Map] Connection error to "), s_Host + " code=" + String(result) + " " + HTTPClient::errorToString(result));
 			}
 			_http.end();
 
 		} else {
-			debug_outln_info(F("Failed connecting to "), s_Host);
+			debug_outln_error(F("[Map] Cannot connect to host"));
+			debug_outln_verbose(F("[Map] Host: "), s_Host);
 		}
 	}
 	if (num_of_robonomics_host < numRobonomicsHosts) {
-		debug_outln_info(F("Min sensors host - "), HOST_ROBONOMICS[num_of_robonomics_host][0]);
+		debug_outln_verbose(F("[Map] Selected server: "), HOST_ROBONOMICS[num_of_robonomics_host][0]);
 	} else {
-		debug_outln_info(F("No sutable host found"));
+		debug_outln_error(F("[Map] No suitable server found among all hosts"));
 	}
 	
 	return num_of_robonomics_host;

--- a/config_manager/config_helpers.cpp
+++ b/config_manager/config_helpers.cpp
@@ -172,7 +172,9 @@ void readConfig(bool oldconfig) {
 	DynamicJsonDocument json(JSON_BUFFER_SIZE);
 	DeserializationError err = deserializeJson(json, configFile.readString());
 	configFile.close();
+#ifdef DEV
 	serializeJson(json, Serial);
+#endif
 #pragma GCC diagnostic pop
 
 	if (!err) {

--- a/display/driver/EPD_4in2_SSD1683.cpp
+++ b/display/driver/EPD_4in2_SSD1683.cpp
@@ -144,8 +144,10 @@ returns  :  true if display is ready, false if timed out
 ******************************************************************************/
 bool EPD_4IN2_V2_ReadBusy(void)
 {
+#ifdef DEV
     Serial.println(F("[EPD] busy..."));
     Serial.flush();
+#endif
     
     const unsigned long timeout_ms = 30000; // 30 second timeout (display ops can be slow)
     unsigned long start = millis();
@@ -161,6 +163,7 @@ bool EPD_4IN2_V2_ReadBusy(void)
             return false; // Timed out - display stuck
         }
         
+#ifdef DEV
         // Log progress every 5 seconds so we know it's still waiting
         if (now - last_log > 5000) {
             Serial.print(F("[EPD] still busy... "));
@@ -169,13 +172,16 @@ bool EPD_4IN2_V2_ReadBusy(void)
             Serial.flush();
             last_log = now;
         }
+#endif
         
         yield(); // Let FreeRTOS run other tasks (WiFi, buttons, LEDs)
         DEV_Delay_ms(10);
     }
     
+#ifdef DEV
     Serial.println(F("[EPD] busy release"));
     Serial.flush();
+#endif
     return true; // Success
 }
 

--- a/display/screens/display_common.cpp
+++ b/display/screens/display_common.cpp
@@ -228,7 +228,9 @@ void epdSleep() {
 // Attempt to recover from a stuck display by hardware reset and reinit
 void epdRecoverFromStuck() {
 #ifdef DISPLAY_4IN2
+#ifdef DEV
     Serial.println(F("[EPD] Attempting display recovery..."));
+#endif
     
     // Hardware reset
     EPD_4IN2_V2_Reset();
@@ -247,7 +249,9 @@ void epdRecoverFromStuck() {
         period_position_per_screen[i] = 0;
     }
     
+#ifdef DEV
     Serial.println(F("[EPD] Display recovery complete"));
+#endif
 #endif
 }
 

--- a/display/screens/graph.cpp
+++ b/display/screens/graph.cpp
@@ -113,7 +113,7 @@ static bool checkSDCardAvailable() {
     bool isConnected = sdCardLogger.checkInserted();
     if (!isConnected) {
         // Card was removed - update device status
-        debug_outln_info(F("[Graph] SD card removed - updating status"));
+        debug_outln_verbose(F("[Graph] SD card removed - updating status"));
         return false;
     }
     return true;
@@ -122,21 +122,21 @@ static bool checkSDCardAvailable() {
 static bool checkDataFilesExist() {
     // First, verify card is still present (detect removal)
     if (!sdCardLogger.checkInserted()) {
-        debug_outln_info(F("[Graph] SD card removed during file check"));
+        debug_outln_verbose(F("[Graph] SD card removed during file check"));
         return false;
     }
     
     // Refresh SD card cache periodically to detect new files
     unsigned long now = millis();
     if (now - last_file_check_time > FILE_CHECK_INTERVAL_MS || last_file_check_time == 0) {
-        debug_outln_info(F("[Graph] Refreshing SD card cache..."));
+        debug_outln_verbose(F("[Graph] Refreshing SD card cache..."));
         sdCardLogger.refreshCache();
         last_file_check_time = now;
     }
     
     // Check if root folder exists
     if (!SD.exists("/sensors_data")) {
-        debug_outln_info(F("[Graph] /sensors_data folder does not exist"));
+        debug_outln_verbose(F("[Graph] /sensors_data folder does not exist"));
         return false;
     }
     
@@ -148,37 +148,37 @@ static bool checkDataFilesExist() {
              timeinfo->tm_year + 1900, timeinfo->tm_mon + 1, timeinfo->tm_mday);
     
     String dateInfo = "[Graph] Checking for date: " + String(dateStr);
-    debug_outln_info(dateInfo);
+    debug_outln_verbose(dateInfo);
     
     // Check common sensor folders for today's file
     const char* sensors[] = {"SCD4x", "BME680", ATRUIST_URBAN_SENSOR};
     for (int i = 0; i < 3; i++) {
         String filePath = "/sensors_data/" + String(sensors[i]) + "/" + String(dateStr) + ".csv";
         String checkMsg = "[Graph] Checking file: " + filePath;
-        debug_outln_info(checkMsg);
+        debug_outln_verbose(checkMsg);
         if (SD.exists(filePath)) {
             File testFile = SD.open(filePath, FILE_READ);
             if (testFile && testFile.size() > 0) {
                 String foundMsg = "[Graph] Found today's file: " + filePath + " size: " + String(testFile.size());
-                debug_outln_info(foundMsg);
+                debug_outln_verbose(foundMsg);
                 testFile.close();
                 return true;
             }
             if (testFile) {
                 String emptyMsg = "[Graph] File exists but empty or can't read: " + filePath;
-                debug_outln_info(emptyMsg);
+                debug_outln_verbose(emptyMsg);
                 testFile.close();
             }
         } else {
             String notFoundMsg = "[Graph] File does not exist: " + filePath;
-            debug_outln_info(notFoundMsg);
+            debug_outln_verbose(notFoundMsg);
         }
     }
     
     // If direct check didn't find files, do full directory scan
     File root = SD.open("/sensors_data");
     if (!root || !root.isDirectory()) {
-        debug_outln_info(F("[Graph] Failed to open /sensors_data directory"));
+        debug_outln_verbose(F("[Graph] Failed to open /sensors_data directory"));
         return false;
     }
     
@@ -201,7 +201,7 @@ static bool checkDataFilesExist() {
             // Build full path
             String sensorPath = "/sensors_data/" + sensorName;
             String folderInfo = "[Graph] Checking sensor folder: " + sensorPath;
-            debug_outln_info(folderInfo);
+            debug_outln_verbose(folderInfo);
             File sensorDir = SD.open(sensorPath);
             if (sensorDir && sensorDir.isDirectory()) {
                 File csvFile = sensorDir.openNextFile();
@@ -209,10 +209,10 @@ static bool checkDataFilesExist() {
                     String fileName = csvFile.name();
                     fileCount++;
                     String fileInfo = "[Graph] Found file: " + fileName + " size: " + String(csvFile.size());
-                    debug_outln_info(fileInfo);
+                    debug_outln_verbose(fileInfo);
                     if (fileName.endsWith(".csv") && csvFile.size() > 0) {
                         hasData = true;
-                        debug_outln_info(F("[Graph] Found valid CSV file with data"));
+                        debug_outln_verbose(F("[Graph] Found valid CSV file with data"));
                         csvFile.close();
                         sensorDir.close();
                         root.close();
@@ -230,7 +230,7 @@ static bool checkDataFilesExist() {
     root.close();
     
     String checkResult = "[Graph] Checked " + String(sensorCount) + " sensors, " + String(fileCount) + " files total. Has data: " + (hasData ? "yes" : "no");
-    debug_outln_info(checkResult);
+    debug_outln_verbose(checkResult);
     return hasData;
 }
 

--- a/display/screens/main_screen.cpp
+++ b/display/screens/main_screen.cpp
@@ -151,8 +151,7 @@ void drawValue(const char *label, float value, uint8_t precision,
 
     // Draw warning icon and arrow next to the title (label)
     if (has_warning) {
-        String debug_msg = String(F("Drawing warning icon and arrow for dangerous value: ")) + String(label) + F(" = ") + String(value);
-        debug_outln_info(debug_msg);
+        debug_outln_verbose(String(F("Drawing warning icon and arrow for dangerous value: ")) + String(label) + F(" = ") + String(value));
 
         // Warning icon - manually drawn 16x16 filled triangle with exclamation
         const uint16_t warning_size = 16;

--- a/sensors/bmx680i2c_sensor.cpp
+++ b/sensors/bmx680i2c_sensor.cpp
@@ -11,7 +11,7 @@
 #define ESP_TEMP_FACTOR        0.25f   // °C датчика на °C ESP
 #define MAX_ESP_COMP_C         2.5f    // Ограничение безопасности
 
-#define RH_PER_DEG_C           4.5f    // %RH на °C
+#define RH_PER_DEG_C           2.0f    // %RH на °C
 
 BME680Sensor::BME680Sensor(unsigned long sending_timeout)
     : Sensor(sending_timeout) 
@@ -157,7 +157,9 @@ void BME680Sensor::_fetch(JsonDocument &data) {
     addValueToJSON(data, F("pressure"),    last_pressure_value,    INTL_PRESSURE,    F("Pa"));
     addValueToJSON(data, F("humidity"),    last_humidity_value,    INTL_HUMIDITY,    F("%"));
 
+#ifdef DEV
     serializeJson(data, Serial);
+#endif
 
     deinit_i2c();
 }

--- a/sensors/drivers/SCD4x_Library/src/SparkFun_SCD4x_Arduino_Library.cpp
+++ b/sensors/drivers/SCD4x_Library/src/SparkFun_SCD4x_Arduino_Library.cpp
@@ -43,8 +43,10 @@ bool SCD4x::begin(bool measBegin, bool autoCalibrate, bool skipStopPeriodicMeasu
     char serialNumber[13];
     success &= getSerialNumber(serialNumber);
 
+#ifdef DEV
     Serial.print(F("Begin SCD4x serial number: "));
     Serial.println(serialNumber);
+#endif
 
     if (pollAndSetDeviceType) {
         scd4x_sensor_type_e sensorType;

--- a/sensors/drivers/i2c.cpp
+++ b/sensors/drivers/i2c.cpp
@@ -23,7 +23,10 @@ void deinit_i2c(void) {
     esp_err_t ret = i2c_driver_delete(I2C_MASTER_NUM);
     if (ret != ESP_OK) {
         Serial.printf("i2c_driver_delete error: %s\r\n", esp_err_to_name(ret));
-    } else {
+    }
+#ifdef DEV
+    else {
         Serial.printf("I2C driver deleted successfully.\r\n");
     }
+#endif
 }

--- a/sensors/drivers/i2s_noise/measurement.cpp
+++ b/sensors/drivers/i2s_noise/measurement.cpp
@@ -78,10 +78,12 @@ float Measurement::decibel(float v) {
 }
 
 void Measurement::print() {
+#ifdef DEV
   Serial.printf("count=%d min=%.1f max=%.1f avg=%.1f  =>", n, min, max, avg);
   for (int i = 0; i < OCTAVES; i++)
     Serial.printf(" %.1f", spectrum[i]);
   Serial.println();
+#endif
 }
 
 #endif // ESP32

--- a/sensors/http_altruist_sensor.cpp
+++ b/sensors/http_altruist_sensor.cpp
@@ -177,7 +177,9 @@ void HTTPAltruistSensor::_fetch_one_sensor(JsonDocument &data, HTTPClient& http,
             urbanRoot = data.createNestedObject(ATRUIST_URBAN_SENSOR);
             if (urbanRoot.isNull()) {
                 debug_outln_info(F("HTTPAltruistSensor: FAILED to create altruist_urban (JSON memory issue)"));
+#ifdef DEV
                 serializeJson(data, Serial);
+#endif
                 http.end();
                 return;
             }

--- a/sensors/radsens_sensor.cpp
+++ b/sensors/radsens_sensor.cpp
@@ -26,6 +26,8 @@ void RadSensSensor::_fetch(JsonDocument &data) {
 	last_value_gc = radSens.getRadIntensyDynamic();
     debug_outln_info(F("radiation "), last_value_gc);
     addValueToJSON(data, F("radiation"), last_value_gc, INTL_RADIATION, F("µR/h"));
+#ifdef DEV
     serializeJson(data, Serial);
+#endif
     deinit_i2c();
 }

--- a/sensors/scd4x_sensor.cpp
+++ b/sensors/scd4x_sensor.cpp
@@ -53,7 +53,9 @@ void SCD4xSensor::_fetch(JsonDocument &data) {
         addValueToJSON(data, F("co2"), last_co2_value, INTL_CO2, F("ppm"));
         addValueToJSON(data, F("temperature"), last_temerature_value, INTL_TEMPERATURE, F("°C"));
         addValueToJSON(data, F("humidity"), last_humidity_value, INTL_HUMIDITY, F("%"));
+#ifdef DEV
         serializeJson(data, Serial);
+#endif
     }
     deinit_i2c();
 }

--- a/sensors/tiny_gps_sensor.cpp
+++ b/sensors/tiny_gps_sensor.cpp
@@ -33,11 +33,14 @@ void GPSSensor::_fetch(JsonDocument &data) {
     // debug_outln_info(F("radiation "), last_value_gc);
     addValueToJSON(data, F("latitude"), gps.location.lat(), "Latitude", F(""));
     addValueToJSON(data, F("longitude"), gps.location.lng(), "Longitude", F(""));
+#ifdef DEV
     serializeJson(data, Serial);
+#endif
 }
 
 void GPSSensor::displayInfo()
 {
+#ifdef DEV
     Serial.print(F("Location: ")); 
     if (gps.location.isValid())
     {
@@ -85,4 +88,5 @@ void GPSSensor::displayInfo()
     }
 
     Serial.println();
+#endif
 }

--- a/translations/intl_en.h
+++ b/translations/intl_en.h
@@ -141,7 +141,7 @@ const char INTL_SAVE_AND_RESTART[] PROGMEM = "Save configuration and restart";
 #define INTL_IP_ADDRESS "IP Address"
 const char INTL_SD_CONNECTED[] PROGMEM = "SD Card connected";
 const char INTL_FREE_RAM[] PROGMEM = "Free Memory (RAM)";
-const char INTL_LAST_OTA[] PROGMEM = "Last OTA";
+const char INTL_LAST_OTA[] PROGMEM = "Last OTA check";
 #define INTL_OTA_UPDATE "Firmware Update"
 const char INTL_OTA_CHECK_UPDATE[] PROGMEM = "Check for update";
 const char INTL_OTA_CURRENT_VERSION[] PROGMEM = "Current version";

--- a/translations/intl_ru.h
+++ b/translations/intl_ru.h
@@ -141,7 +141,7 @@ const char INTL_SAVE_AND_RESTART[] PROGMEM = "Сохранить и переза
 #define INTL_IP_ADDRESS "IP адрес"
 const char INTL_SD_CONNECTED[] PROGMEM = "SD карта подключена";
 const char INTL_FREE_RAM[] PROGMEM = "Свободно памяти (ОЗУ)";
-const char INTL_LAST_OTA[] PROGMEM = "Последний OTA";
+const char INTL_LAST_OTA[] PROGMEM = "Последняя проверка OTA";
 #define INTL_OTA_UPDATE "Обновление прошивки"
 const char INTL_OTA_CHECK_UPDATE[] PROGMEM = "Проверить обновление";
 const char INTL_OTA_CURRENT_VERSION[] PROGMEM = "Текущая версия";

--- a/utils.cpp
+++ b/utils.cpp
@@ -451,13 +451,12 @@ void incrementTXCounter() {
 
 // Log metrics to UART in the specified format
 void logMetrics() {
+#ifdef DEV
 	updateMetrics();
 	
-	// Determine status
 	const char* status = system_metrics.has_error ? "ERROR" : "ALIVE";
 	const char* status_symbol = system_metrics.has_error ? "✗" : "✓";
 	
-	// Get WiFi state
 	const char* wifi_state = "DISCONNECTED";
 	const char* wifi_symbol = "✗";
 	int rssi = 0;
@@ -467,19 +466,16 @@ void logMetrics() {
 		rssi = WiFi.RSSI();
 	}
 	
-	// Format uptime
 	unsigned long hours = system_metrics.uptime_sec / 3600;
 	unsigned long minutes = (system_metrics.uptime_sec % 3600) / 60;
 	unsigned long seconds = system_metrics.uptime_sec % 60;
 	
-	// Add device identification
 	#if defined(ALTRUIST_INSIDE)
 	Serial.print(F("\r\n=== [INSIGHT] METRICS ===\r\n"));
 	#elif defined(ALTRUIST_URBAN)
 	Serial.print(F("\r\n=== [URBAN] METRICS ===\r\n"));
 	#endif
 	
-	// Status line
 	Serial.print(F("Status: "));
 	Serial.print(status_symbol);
 	Serial.print(F(" "));
@@ -493,7 +489,6 @@ void logMetrics() {
 	}
 	Serial.print(F("\r\n"));
 	
-	// Uptime line
 	Serial.print(F("Uptime: "));
 	if (hours > 0) {
 		Serial.print(hours);
@@ -508,12 +503,10 @@ void logMetrics() {
 	Serial.print(system_metrics.uptime_sec);
 	Serial.print(F("s total)\r\n"));
 	
-	// Boot counter
 	Serial.print(F("Boot: "));
 	Serial.print(system_metrics.boot_counter);
 	Serial.print(F("\r\n"));
 	
-	// WiFi line
 	Serial.print(F("WiFi: "));
 	Serial.print(wifi_symbol);
 	Serial.print(F(" "));
@@ -525,7 +518,6 @@ void logMetrics() {
 	}
 	Serial.print(F("\r\n"));
 	
-	// TX counter
 	Serial.print(F("TX: "));
 	Serial.print(system_metrics.tx_counter);
 	if (system_metrics.last_telemetry_timestamp > 0) {
@@ -538,7 +530,6 @@ void logMetrics() {
 	}
 	Serial.print(F("\r\n"));
 	
-	// Error counters
 	Serial.print(F("Errors: WiFi="));
 	Serial.print(system_metrics.err_wifi_reconnects);
 	Serial.print(F(" Sensor="));
@@ -547,10 +538,10 @@ void logMetrics() {
 	Serial.print(system_metrics.err_sd_write);
 	Serial.print(F("\r\n"));
 	
-	// ESP temperature
 	Serial.print(F("ESP Temp: "));
 	Serial.print(system_metrics.esp_temperature, 1);
 	Serial.print(F("°C\r\n"));
 	
 	Serial.print(F("==========================\r\n"));
+#endif
 }

--- a/utils.h
+++ b/utils.h
@@ -73,7 +73,7 @@ struct api_status_t {
 	bool is_ok = true;
 	unsigned long count_sends = 0;
 	unsigned long count_sends_success = 0;
-	time_t last_send_time;
+	time_t last_send_time = 0;
 };
 
 struct device_status_t {

--- a/webserver/html-content.h
+++ b/webserver/html-content.h
@@ -60,7 +60,7 @@ const char WEB_PAGE_HEADER_BODY[] PROGMEM = "<div class='canvas-info'>\
     <small>\
     <span>ID</span>: {id}<br />\
     <span>" INTL_FIRMWARE "</span>: " SOFTWARE_VERSION_STR "/" INTL_LANG "&nbsp;(" __DATE__ ")<br/>\
-    <span>" INTL_ROBONOMICS_ADDR "</span>: {addr}\
+    <span>" INTL_ROBONOMICS_ADDR "</span>: <span style='cursor:pointer;border-bottom:1px dashed #999;font-weight:normal' title='Click to copy' onclick='var s=this,t=document.createElement(\"textarea\");t.value=s.innerText;t.style.position=\"fixed\";t.style.opacity=\"0\";document.body.appendChild(t);t.select();document.execCommand(\"copy\");document.body.removeChild(t);s.style.opacity=0.5;setTimeout(function(){s.style.opacity=1},300)'>{addr}</span>\
     </small>\
     </div>\
     </div><div class='content'><h4 class='content-subtitle'>" INTL_HOME " {n} {t}</h4>";
@@ -70,7 +70,7 @@ const char WEB_PAGE_DEBUG_HEADER_BODY[] PROGMEM = "<div class='canvas-info'>\
     <small>\
     <span>ID</span>: {id}<br />\
     <span>" INTL_FIRMWARE "</span>: " SOFTWARE_VERSION_STR "/" INTL_LANG "&nbsp;(" __DATE__ ")<br/>\
-    <span>" INTL_ROBONOMICS_ADDR "</span>: {addr}\
+    <span>" INTL_ROBONOMICS_ADDR "</span>: <span style='cursor:pointer;border-bottom:1px dashed #999;font-weight:normal' title='Click to copy' onclick='var s=this,t=document.createElement(\"textarea\");t.value=s.innerText;t.style.position=\"fixed\";t.style.opacity=\"0\";document.body.appendChild(t);t.select();document.execCommand(\"copy\");document.body.removeChild(t);s.style.opacity=0.5;setTimeout(function(){s.style.opacity=1},300)'>{addr}</span>\
     </small>\
     </div>\
     </div><div class='content content-debug'><h4 class='content-subtitle'>" INTL_HOME " {n} {t}</h4>";
@@ -80,7 +80,7 @@ const char WEB_PAGE_CONFIG_HEADER_BODY[] PROGMEM = "<div class='canvas-info'>\
     <small>\
     <span>ID</span>: {id}<br />\
     <span>" INTL_FIRMWARE "</span>: " SOFTWARE_VERSION_STR "/" INTL_LANG "&nbsp;(" __DATE__ ")<br/>\
-    <span>" INTL_ROBONOMICS_ADDR "</span>: {addr}\
+    <span>" INTL_ROBONOMICS_ADDR "</span>: <span style='cursor:pointer;border-bottom:1px dashed #999;font-weight:normal' title='Click to copy' onclick='var s=this,t=document.createElement(\"textarea\");t.value=s.innerText;t.style.position=\"fixed\";t.style.opacity=\"0\";document.body.appendChild(t);t.select();document.execCommand(\"copy\");document.body.removeChild(t);s.style.opacity=0.5;setTimeout(function(){s.style.opacity=1},300)'>{addr}</span>\
     </small>\
     </div>\
     </div><div class='content content-config'><h4 class='content-subtitle'>" INTL_HOME " {n} {t}</h4>";

--- a/webserver/pages/config.cpp
+++ b/webserver/pages/config.cpp
@@ -84,8 +84,6 @@ void webserver_config_send_body_get(WebServer &server, String& page_content, boo
 	add_form_input(page_content, Config_datalog_sending_intervall_ms, FPSTR(INTL_DATALOG_SENDING_INTERVAL), 5);
 	add_form_input(page_content, Config_robonomics_public_node, FPSTR(INTL_ROBONOMICS_PUBLIC_NODE), LEN_ROBONOMICS_PUBLIC_NODE-1);
 
-	// Data postin to the map (inside Robonomics panel) - only visible in dev builds for now
-#ifdef DEV
 	page_content += F("<h3 class='panel-subtitle' style='margin-top:16px;'>" INTL_PANEL_TITLE_DATA_SHARING "</h3>");
 	page_content += F("<p style='font-size:0.9em;color:#555;margin-bottom:12px;'>"
 		INTL_DATA_SHARING_DISCLAIMER
@@ -104,7 +102,6 @@ void webserver_config_send_body_get(WebServer &server, String& page_content, boo
 	add_form_checkbox(Config_share_pm, FPSTR(INTL_SHARE_PM), true);
 	add_form_checkbox(Config_share_noise, FPSTR(INTL_SHARE_NOISE), true);
 #endif
-#endif // DEV
 	page_content += F("</div>");
 
 	server.sendContent(page_content);

--- a/webserver/pages/guest.cpp
+++ b/webserver/pages/guest.cpp
@@ -55,12 +55,13 @@ void webserver_guest_create_body_get_part1(String& page_content, bool wificonfig
     }
 	page_content += F("</ul>");
 
-	// Data posting to the map disclaimer and configuration - only visible in dev builds for now
-#ifdef DEV
-	page_content += F("<h3 class='guest-subtitle'>" INTL_PANEL_TITLE_DATA_SHARING "</h3>");
-	page_content += F("<p class='disclaimer' style='font-size:0.9em;color:#555;margin-bottom:12px;'>"
-		INTL_DATA_SHARING_DISCLAIMER
-		"</p>");
+	page_content += F(
+		"<div style='margin-top:30px;padding:16px 20px;border:2px solid #2949d3;border-radius:10px;background:#f0f4ff;'>"
+		"<h3 class='guest-subtitle' style='margin-bottom:12px;'>" INTL_PANEL_TITLE_DATA_SHARING "</h3>"
+		"<p style='font-size:14px;color:#333;margin:0 0 14px;line-height:1.6;'>"
+		"&#9432;&nbsp;" INTL_DATA_SHARING_DISCLAIMER
+		"</p>"
+		"<div style='padding:8px 0;'>");
 	page_content += form_checkbox(Config_share_temperature, FPSTR(INTL_SHARE_TEMPERATURE), false);
 	page_content += form_checkbox(Config_share_humidity, FPSTR(INTL_SHARE_HUMIDITY), false);
 	page_content += form_checkbox(Config_share_pressure, FPSTR(INTL_SHARE_PRESSURE), false);
@@ -71,7 +72,7 @@ void webserver_guest_create_body_get_part1(String& page_content, bool wificonfig
 	page_content += form_checkbox(Config_share_pm, FPSTR(INTL_SHARE_PM), false);
 	page_content += form_checkbox(Config_share_noise, FPSTR(INTL_SHARE_NOISE), false);
 #endif
-#endif // DEV
+	page_content += F("</div></div>");
 }
 
 void webserver_guest_create_body_get_part2(String& page_content, bool wificonfig_loop) {

--- a/webserver/pages/status.cpp
+++ b/webserver/pages/status.cpp
@@ -50,7 +50,16 @@ void webserver_status_part2(String &page_content, device_status_t &deviceStatus)
     for (const auto& [key, value] : deviceStatus.apis_status) {
         String api_is_ok = value.is_ok ? "OK" : "ERROR";
         String api_count_sends = String(value.count_sends_success) + "/" + String(value.count_sends);
-        String api_last_send = ctime(&value.last_send_time);
+        String api_last_send;
+        if (value.last_send_time == 0) {
+            api_last_send = "N/A";
+        } else {
+            struct tm ti;
+            localtime_r(&value.last_send_time, &ti);
+            char buf[24];
+            strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &ti);
+            api_last_send = buf;
+        }
 		std::string boldKey = "<b>" + key + "</b>";
         add_table_row_from_value(page_content, boldKey.c_str(), api_is_ok);
         add_table_row_from_value(page_content, FPSTR(INTL_COUNT_SUCCESS_SENDS), api_count_sends);

--- a/webserver/webserver.cpp
+++ b/webserver/webserver.cpp
@@ -469,6 +469,7 @@ void SensorWebServer::_webserver_ota() {
 				page_content += FPSTR(INTL_OTA_LANG_REQUESTED);
 				page_content += F("</h3></div>");
 			}
+			
 		} else {
 			deviceStatus.ota_update_requested = true;
 			page_content += F("<div style='text-align:center;padding:30px;'>"


### PR DESCRIPTION
### 1. "Publish to Map" checkboxes:
- Users can choose which sensor values to share on the public map
- Improved guest page UI: added a visually distinct blue-bordered section with an info icon and disclaimer so first-time users clearly see what data they're sharing

### 2. Device status — "last send time" display fix

### 3. Improved Robonomics API error logging

### 4. BME680 → SCD4x temperature/humidity switching for map data (same as e-ink display)

### 6. Robonomics address copy-on-click
- Added click-to-copy for the Robonomics address in the webserver header

### 7. Clean up production build logs
Wrapped diagnostic-only serial output in `#ifdef DEV` so production builds have clean serial
