### PR TITLE
added additional sensors to choose from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 All notable changes to the Altruist Firmware project will be documented in this file.
 
-## [R_2026-04.1](https://github.com/airalab/altruist-firmware/releases/tag/R_2026-04.1) — 2026-04-09
+## [R_2026-04.2](https://github.com/airalab/altruist-firmware/releases/tag/v_R_2026-04.2) — 2026-04-15
+
+### Improvements
+
+- **Publish to Map: additional Urban sensors** — added optional toggles for Radiation, O3, NO2, FAST AQI, and EPA AQI; shown under a dedicated “Additional sensors (optional)” section (off by default).
+
+## [R_2026-04.1](https://github.com/airalab/altruist-firmware/releases/tag/v_R_2026-04.1) — 2026-04-09
 
 ### Bug Fixes
 
@@ -14,7 +20,7 @@ All notable changes to the Altruist Firmware project will be documented in this 
 - **Analytics (Insight) clarity & layout polish** — analytics metric cards now explicitly indicate values are the _night average_ via an in-card label (`night avg`) and improved vertical spacing for better readability.
 - **Main screen (Insight) source clarity** — Urban-only metrics (Noise, PM) are labeled as `Urban only` to avoid confusion when viewing combined Urban/Insight data.
 
-## [R_2026-04](https://github.com/airalab/altruist-firmware/releases/tag/R_2026-04) — 2026-04-01
+## [R_2026-04](https://github.com/airalab/altruist-firmware/releases/tag/v_R_2026-04) — 2026-04-01
 
 ### Bug Fixes
 

--- a/config_manager/airrohr-cfg.h
+++ b/config_manager/airrohr-cfg.h
@@ -91,6 +91,11 @@ enum ConfigShapeId {
 	Config_share_co2,
 	Config_share_pm,
 	Config_share_noise,
+	Config_share_radiation,
+	Config_share_o3,
+	Config_share_no2,
+	Config_share_fast_aqi,
+	Config_share_epa_aqi,
 };
 static constexpr char CFG_KEY_CURRENT_LANG[] PROGMEM = "current_lang";
 static constexpr char CFG_KEY_WLANSSID[] PROGMEM = "wlanssid";
@@ -154,6 +159,11 @@ static constexpr char CFG_KEY_SHARE_PRESSURE[] PROGMEM = "share_pressure";
 static constexpr char CFG_KEY_SHARE_CO2[] PROGMEM = "share_co2";
 static constexpr char CFG_KEY_SHARE_PM[] PROGMEM = "share_pm";
 static constexpr char CFG_KEY_SHARE_NOISE[] PROGMEM = "share_noise";
+static constexpr char CFG_KEY_SHARE_RADIATION[] PROGMEM = "share_radiation";
+static constexpr char CFG_KEY_SHARE_O3[] PROGMEM = "share_o3";
+static constexpr char CFG_KEY_SHARE_NO2[] PROGMEM = "share_no2";
+static constexpr char CFG_KEY_SHARE_FAST_AQI[] PROGMEM = "share_fast_aqi";
+static constexpr char CFG_KEY_SHARE_EPA_AQI[] PROGMEM = "share_epa_aqi";
 static constexpr ConfigShapeEntry configShape[] PROGMEM = {
 	{ Config_Type_String, sizeof(cfg::current_lang)-1, CFG_KEY_CURRENT_LANG, cfg::current_lang },
 	{ Config_Type_String, sizeof(cfg::wlanssid)-1, CFG_KEY_WLANSSID, cfg::wlanssid },
@@ -217,6 +227,11 @@ static constexpr ConfigShapeEntry configShape[] PROGMEM = {
 	{ Config_Type_Bool, 0, CFG_KEY_SHARE_CO2, &cfg::share_co2 },
 	{ Config_Type_Bool, 0, CFG_KEY_SHARE_PM, &cfg::share_pm },
 	{ Config_Type_Bool, 0, CFG_KEY_SHARE_NOISE, &cfg::share_noise },
+	{ Config_Type_Bool, 0, CFG_KEY_SHARE_RADIATION, &cfg::share_radiation },
+	{ Config_Type_Bool, 0, CFG_KEY_SHARE_O3, &cfg::share_o3 },
+	{ Config_Type_Bool, 0, CFG_KEY_SHARE_NO2, &cfg::share_no2 },
+	{ Config_Type_Bool, 0, CFG_KEY_SHARE_FAST_AQI, &cfg::share_fast_aqi },
+	{ Config_Type_Bool, 0, CFG_KEY_SHARE_EPA_AQI, &cfg::share_epa_aqi },
 };
           
 #endif // __CONFIG_H__

--- a/config_manager/config_defaults.cpp
+++ b/config_manager/config_defaults.cpp
@@ -85,6 +85,12 @@ namespace cfg {
 	bool share_co2 = true;
 	bool share_pm = true;
 	bool share_noise = true;
+	// Additional (optional) sensors: default OFF (most devices don't have them)
+	bool share_radiation = false;
+	bool share_o3 = false;
+	bool share_no2 = false;
+	bool share_fast_aqi = false;
+	bool share_epa_aqi = false;
 
 	void initNonTrivials(const char* id) {
 		strcpy(cfg::current_lang, CURRENT_LANG);

--- a/config_manager/config_defaults.h
+++ b/config_manager/config_defaults.h
@@ -86,6 +86,11 @@ namespace cfg {
 	extern bool share_co2;
 	extern bool share_pm;
 	extern bool share_noise;
+	extern bool share_radiation;
+	extern bool share_o3;
+	extern bool share_no2;
+	extern bool share_fast_aqi;
+	extern bool share_epa_aqi;
 
 	extern void initNonTrivials(const char* id);
 }

--- a/translations/intl_en.h
+++ b/translations/intl_en.h
@@ -93,12 +93,18 @@ const char INTL_BASICAUTH[] PROGMEM = "Authentication";
 #define INTL_PANEL_TITLE_INFLUX "Ifnlux DB"
 #define INTL_PANEL_TITLE_DATA_SHARING "Publish to Map"
 #define INTL_DATA_SHARING_DISCLAIMER "By default, all sensor data is shared to the public sensors map. You can choose which data types to share below. Unshared data will still be displayed on your device screen and available locally."
+#define INTL_DATA_SHARING_ADDITIONAL "Additional sensors (optional)"
 const char INTL_SHARE_TEMPERATURE[] PROGMEM = "Temperature";
 const char INTL_SHARE_HUMIDITY[] PROGMEM = "Humidity";
 const char INTL_SHARE_PRESSURE[] PROGMEM = "Pressure";
 const char INTL_SHARE_CO2[] PROGMEM = "CO2";
 const char INTL_SHARE_PM[] PROGMEM = "Particulate Matter (PM2.5/PM10)";
 const char INTL_SHARE_NOISE[] PROGMEM = "Noise Level";
+const char INTL_SHARE_RADIATION[] PROGMEM = "Radiation";
+const char INTL_SHARE_O3[] PROGMEM = "Ozone (O3)";
+const char INTL_SHARE_NO2[] PROGMEM = "Nitrogen dioxide (NO2)";
+const char INTL_SHARE_FAST_AQI[] PROGMEM = "FAST AQI";
+const char INTL_SHARE_EPA_AQI[] PROGMEM = "EPA AQI";
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "WiFi Sensor in configuration mode";
 const char INTL_FS_WIFI_NAME[] PROGMEM = "Network name";

--- a/translations/intl_ru.h
+++ b/translations/intl_ru.h
@@ -93,12 +93,18 @@ const char INTL_BASICAUTH[] PROGMEM = "Активировать аутентиф
 #define INTL_PANEL_TITLE_INFLUX "Ifnlux DB"
 #define INTL_PANEL_TITLE_DATA_SHARING "Публикация на карту"
 #define INTL_DATA_SHARING_DISCLAIMER "По умолчанию все данные датчиков отправляются на публичную карту. Вы можете выбрать, какие данные передавать. Остальные данные будут отображаться на экране устройства и доступны локально."
+#define INTL_DATA_SHARING_ADDITIONAL "Доп. датчики (опционально)"
 const char INTL_SHARE_TEMPERATURE[] PROGMEM = "Температура";
 const char INTL_SHARE_HUMIDITY[] PROGMEM = "Влажность";
 const char INTL_SHARE_PRESSURE[] PROGMEM = "Давление";
 const char INTL_SHARE_CO2[] PROGMEM = "CO2";
 const char INTL_SHARE_PM[] PROGMEM = "Пыль (PM2.5/PM10)";
 const char INTL_SHARE_NOISE[] PROGMEM = "Уровень шума";
+const char INTL_SHARE_RADIATION[] PROGMEM = "Радиация";
+const char INTL_SHARE_O3[] PROGMEM = "Озон (O3)";
+const char INTL_SHARE_NO2[] PROGMEM = "Диоксид азота (NO2)";
+const char INTL_SHARE_FAST_AQI[] PROGMEM = "FAST AQI";
+const char INTL_SHARE_EPA_AQI[] PROGMEM = "EPA AQI";
 
 const char INTL_FS_WIFI_DESCRIPTION[] PROGMEM = "Название WiFi устройства в режиме конфигурации";
 const char INTL_FS_WIFI_NAME[] PROGMEM = "Имя";

--- a/webserver/pages/config.cpp
+++ b/webserver/pages/config.cpp
@@ -318,6 +318,14 @@ void webserver_config_send_body_get(WebServer &server, String& page_content, boo
 #ifdef ALTRUIST_URBAN
 	add_form_checkbox(Config_share_pm, FPSTR(INTL_SHARE_PM), true);
 	add_form_checkbox(Config_share_noise, FPSTR(INTL_SHARE_NOISE), true);
+	page_content += F("<div style='margin-top:14px;margin-bottom:14px;font-size:0.9em;color:#666;'>");
+	page_content += F(INTL_DATA_SHARING_ADDITIONAL);
+	page_content += F("</div>");
+	add_form_checkbox(Config_share_radiation, FPSTR(INTL_SHARE_RADIATION), true);
+	add_form_checkbox(Config_share_o3, FPSTR(INTL_SHARE_O3), true);
+	add_form_checkbox(Config_share_no2, FPSTR(INTL_SHARE_NO2), true);
+	add_form_checkbox(Config_share_fast_aqi, FPSTR(INTL_SHARE_FAST_AQI), true);
+	add_form_checkbox(Config_share_epa_aqi, FPSTR(INTL_SHARE_EPA_AQI), true);
 #endif
 	page_content += F("</div>");
 

--- a/webserver/pages/guest.cpp
+++ b/webserver/pages/guest.cpp
@@ -71,6 +71,14 @@ void webserver_guest_create_body_get_part1(String& page_content, bool wificonfig
 #ifdef ALTRUIST_URBAN
 	page_content += form_checkbox(Config_share_pm, FPSTR(INTL_SHARE_PM), false);
 	page_content += form_checkbox(Config_share_noise, FPSTR(INTL_SHARE_NOISE), false);
+	page_content += F("<div style='margin-top:14px;margin-bottom:14px;font-size:14px;color:#555;'>");
+	page_content += F(INTL_DATA_SHARING_ADDITIONAL);
+	page_content += F("</div>");
+	page_content += form_checkbox(Config_share_radiation, FPSTR(INTL_SHARE_RADIATION), false);
+	page_content += form_checkbox(Config_share_o3, FPSTR(INTL_SHARE_O3), false);
+	page_content += form_checkbox(Config_share_no2, FPSTR(INTL_SHARE_NO2), false);
+	page_content += form_checkbox(Config_share_fast_aqi, FPSTR(INTL_SHARE_FAST_AQI), false);
+	page_content += form_checkbox(Config_share_epa_aqi, FPSTR(INTL_SHARE_EPA_AQI), false);
 #endif
 	page_content += F("</div></div>");
 }


### PR DESCRIPTION
**Publish to Map: additional Urban sensors** — added optional toggles for Radiation, O3, NO2, FAST AQI, and EPA AQI; shown under a dedicated “Additional sensors (optional)” section (off by default).