### PR TITLE
some improvements 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the Altruist Firmware project will be documented in this file.
 
+## [R_2026-05.01](https://github.com/airalab/altruist-firmware/releases/tag/v_R_2026-05.01) — 2026-05-25
+
+### Improvements
+
+- **Limited ZMOD4510 sensor info wait time** — reduced ZMOD4510 read_sensor_info timeout from 200s to 10s to avoid blocking Urban boot when the sensor stays busy or does not respond.
+
+### Bug Fixes
+
+- **Renamed Robonomics datalog keys for CO and CO2** :
+  - co2 -> co2
+  - co -> co
+
 ## [R_2026-05](https://github.com/airalab/altruist-firmware/releases/tag/v_R_2026-05) — 2026-05-15
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Altruist Firmware project will be documented in this 
 ### Improvements
 
 - **Limited ZMOD4510 sensor info wait time** — reduced ZMOD4510 read_sensor_info timeout from 200s to 10s to avoid blocking Urban boot when the sensor stays busy or does not respond.
+- **Urban LED states** — simplified Urban LED behavior: steady green for normal operation, blue for configuration mode and active datalog sending, 3-second green/red result after datalog transmission, and steady red only after sustained Wi-Fi/API errors.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ All notable changes to the Altruist Firmware project will be documented in this 
 - **Renamed Robonomics datalog keys for CO and CO2** :
   - co2 -> co2
   - co -> co
+- **SDS011: no placeholder PM values** — stopped publishing `P1`/`P2` with `-1` before the first valid SDS011 measurement; PM values are now written only after a valid averaging window.
+- **SDS011 runtime recovery** — added detection of consecutive empty SDS011 measurement windows and UART/protocol recovery without reboot (drain UART, reinitialize Serial1 on ESP32, reset parser state, and restart the measurement cycle).
+- **Urban SDS cache cleanup on Insight** — Insight now removes stale Urban `SDS_P1`/`SDS_P2` values from its local cache if Urban no longer includes them in `/data.json`, so UI and payloads do not keep outdated PM values.
+- **Telemetry payload safety** — API sends now use a JSON snapshot copied under mutex, and sensor JSON overflow is logged after fetches to help diagnose disappearing fields.
 
 ## [R_2026-05](https://github.com/airalab/altruist-firmware/releases/tag/v_R_2026-05) — 2026-05-15
 

--- a/airrohr-firmware.ino
+++ b/airrohr-firmware.ino
@@ -112,8 +112,9 @@ String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
 // Needed for Arduino .ino auto-generated prototypes in non-INSIDE builds.
 struct analytics_screen_values_t;
 
+static constexpr size_t SENSORS_JSON_CAPACITY = 4096;
 SemaphoreHandle_t mutex = xSemaphoreCreateMutex();
-DynamicJsonDocument sensors_data(2048);
+DynamicJsonDocument sensors_data(SENSORS_JSON_CAPACITY);
 device_status_t deviceStatus;
 #if defined(USE_SD_CARD)
 SDCard sdCardLogger;
@@ -592,6 +593,12 @@ bool fetchSensors() {
 					if (sensor_json_updated) {
 						any_sensor_json_updated = true;
 					}
+					if (sensors_data.overflowed()) {
+						debug_outln_error(F("[Sensors] JSON overflow after fetch"));
+						debug_outln_info(F("[Sensors] sensor: "), String(activeSensors[i]->sensor_name));
+						debug_outln_info(F("[Sensors] memory/capacity: "),
+						                 String(sensors_data.memoryUsage()) + "/" + String(sensors_data.capacity()));
+					}
 					xSemaphoreGive(mutex);
 				}
 #if defined(USE_SD_CARD)
@@ -731,13 +738,23 @@ void sensorAndAPIWorker(void *pvParameters) {
 				markCrashSection(CRASH_SECTION_CUSTOM_HTTP);
 			}
 			
-			// Only hold mutex briefly for the quick signal strength update
-			// Don't hold during send() - it does slow HTTP operations
+			DynamicJsonDocument api_snapshot(SENSORS_JSON_CAPACITY);
+			bool snapshot_ok = false;
 			if (xSemaphoreTake(mutex, portMAX_DELAY)) {
 				sensors_data["service_data"]["signal_strength"] = WiFi.RSSI();
+				api_snapshot.set(sensors_data.as<JsonVariantConst>());
+				snapshot_ok = !api_snapshot.overflowed();
+				if (!snapshot_ok) {
+					debug_outln_error(F("[API] JSON snapshot overflow; skipping send"));
+					debug_outln_info(F("[API] memory/capacity: "),
+					                 String(api_snapshot.memoryUsage()) + "/" + String(api_snapshot.capacity()));
+				}
 				xSemaphoreGive(mutex);
 			}
-			activeAPIs[i]->send(sensors_data);
+			if (!snapshot_ok) {
+				continue;
+			}
+			activeAPIs[i]->send(api_snapshot);
 			incrementTXCounter(); // Track successful telemetry send
 			activeAPIs[i]->updateDeviceStatus(deviceStatus);
 			

--- a/airrohr-firmware.ino
+++ b/airrohr-firmware.ino
@@ -129,6 +129,10 @@ button_pressed_t btn_press;
 
 #if defined(ALTRUIST_URBAN)
 LedControllerUrban leds_controller_urban;
+static volatile bool urban_api_status_ok = true;
+static volatile bool urban_datalog_sending = false;
+static volatile int urban_datalog_result = 0;
+static volatile unsigned long urban_datalog_result_until_ms = 0;
 #endif
 #if defined(ALTRUIST_INSIDE)
 LedControllerInsight leds_controller_insight(sensors_data, mutex);
@@ -754,7 +758,25 @@ void sensorAndAPIWorker(void *pvParameters) {
 			if (!snapshot_ok) {
 				continue;
 			}
+#ifdef ALTRUIST_URBAN
+			const bool urban_is_datalog_send = (activeAPIs[i] == &robonomicsDatalogAPI);
+			if (urban_is_datalog_send) {
+				urban_datalog_result = 0;
+				urban_datalog_sending = true;
+				leds_controller_urban.setMode(LedMode::BLUE);
+				leds_controller_urban.process();
+			}
+#endif
 			activeAPIs[i]->send(api_snapshot);
+#ifdef ALTRUIST_URBAN
+			if (urban_is_datalog_send) {
+				urban_datalog_sending = false;
+				urban_datalog_result = activeAPIs[i]->lastSendWasOk() ? 1 : -1;
+				urban_datalog_result_until_ms = millis() + 3000UL;
+				leds_controller_urban.setMode(urban_datalog_result > 0 ? LedMode::GREEN : LedMode::RED);
+				leds_controller_urban.process();
+			}
+#endif
 			incrementTXCounter(); // Track successful telemetry send
 			activeAPIs[i]->updateDeviceStatus(deviceStatus);
 			
@@ -796,19 +818,7 @@ void sensorAndAPIWorker(void *pvParameters) {
 				senders_ok = senders_ok && status.is_ok;
 			}
 #ifdef ALTRUIST_URBAN
-			// Urban LED policy:
-			// - Keep connection/status LED steady (handled elsewhere: GREEN/PROVISIONING/etc.)
-			// - Blink activity LED ONLY on errors, rate-limited.
-			{
-				static unsigned long last_error_blink_ms = 0;
-				const unsigned long ERROR_BLINK_MIN_INTERVAL_MS = 60UL * 1000UL;
-				if (!senders_ok) {
-					if (last_error_blink_ms == 0 || msSince(last_error_blink_ms) > ERROR_BLINK_MIN_INTERVAL_MS) {
-						last_error_blink_ms = millis();
-						leds_controller_urban.setMode(LedMode::BLINK_RED);
-					}
-				}
-			}
+			urban_api_status_ok = senders_ok;
 #endif
 			}
 		}
@@ -822,19 +832,36 @@ void ledsWorker(void *pvParameters) {
 		vTaskDelay(10 / portTICK_PERIOD_MS);
 		markCrashSection(CRASH_SECTION_LED_UPDATE);
 #ifdef ALTRUIST_URBAN
-		{
-			const wifi_mode_t mode_now = WiFi.getMode();
-			// Same "LAN usable" test as WiFi recovery / mDNS: WL_CONNECTED alone can lie (no DHCP yet).
-			if (wifiStaLinkReady()) {
-				leds_controller_urban.setMode(LedMode::GREEN);
-			} else if (wifiIsConfigPortalRunning() || mode_now == WIFI_AP || mode_now == WIFI_AP_STA) {
-				leds_controller_urban.setMode(LedMode::PROVISIONING);
-			} else if (wifiHasSavedStationCredentials()) {
-				leds_controller_urban.setMode(LedMode::BLUE);
-			} else {
-				leds_controller_urban.setMode(LedMode::NONE);
+		const bool urban_has_saved_wifi = wifiHasSavedStationCredentials();
+		const bool urban_config_mode = !urban_has_saved_wifi || wifiIsConfigPortalRunning();
+		const bool urban_error_now = urban_has_saved_wifi && (!wifiStaLinkReady() || !urban_api_status_ok);
+		const unsigned long urban_now_ms = millis();
+		const bool urban_datalog_result_active = urban_datalog_result != 0 &&
+			(long)(urban_datalog_result_until_ms - urban_now_ms) > 0;
+		static unsigned long urban_error_since_ms = 0;
+
+		LedMode urban_led_mode = LedMode::GREEN;
+		if (urban_datalog_sending) {
+			urban_led_mode = LedMode::BLUE;
+		} else if (urban_datalog_result_active) {
+			urban_led_mode = urban_datalog_result > 0 ? LedMode::GREEN : LedMode::RED;
+		} else if (urban_config_mode) {
+			urban_error_since_ms = 0;
+			urban_datalog_result = 0;
+			urban_led_mode = LedMode::PROVISIONING;
+		} else if (urban_error_now) {
+			if (urban_error_since_ms == 0) {
+				urban_error_since_ms = millis();
 			}
+			urban_datalog_result = 0;
+			urban_led_mode = msSince(urban_error_since_ms) > 10UL * 60UL * 1000UL ? LedMode::RED : LedMode::GREEN;
+		} else {
+			urban_error_since_ms = 0;
+			urban_datalog_result = 0;
+			urban_led_mode = LedMode::GREEN;
 		}
+
+		leds_controller_urban.setMode(urban_led_mode);
 		leds_controller_urban.process();
 #endif
 #ifdef ALTRUIST_INSIDE
@@ -1082,6 +1109,10 @@ void setup(void) {
 	debug_outln_info(F("Altruist: " SOFTWARE_VERSION_STR "/"), String(CURRENT_LANG));
 
 	init_config();
+#ifdef ALTRUIST_URBAN
+	leds_controller_urban.setMode(wifiHasSavedStationCredentials() ? LedMode::GREEN : LedMode::PROVISIONING);
+	leds_controller_urban.process();
+#endif
 	// Sync config language with actual compiled firmware language.
 	// Covers: USB reflash with different locale, failed OTA language switch.
 #ifdef ALTRUIST_INSIDE
@@ -1236,13 +1267,7 @@ void setup(void) {
 #endif
 
 #ifdef ALTRUIST_URBAN
-	if (wifiStaLinkReady()) {
-		leds_controller_urban.setMode(LedMode::GREEN);
-	} else if (wifiHasSavedStationCredentials()) {
-		leds_controller_urban.setMode(LedMode::BLUE);
-	} else {
-		leds_controller_urban.setMode(LedMode::NONE);
-	}
+	leds_controller_urban.setMode(LedMode::GREEN);
 	leds_controller_urban.process();
 #endif
 

--- a/apis/api.h
+++ b/apis/api.h
@@ -51,6 +51,10 @@ public:
         return (millis() - last_send_time > timeout);
     }
 
+    bool lastSendWasOk() const {
+        return is_ok;
+    }
+
     void send(JsonDocument &data) {
         _send(data);
         updateSendTime();

--- a/apis/helpers/message_formatter.cpp
+++ b/apis/helpers/message_formatter.cpp
@@ -43,8 +43,8 @@ void formatRobonomicsString(JsonDocument &data, String &datalog_data) {
             else if (type == "humidity" && cfg::share_humidity && datalog_data.indexOf("h:") == -1
                      && !skip_temp_hum) datalog_data += "h:" + value + ",";
             else if (type == "radiation") datalog_data += "gc:" + value + ",";
-            else if (type == "co2" && cfg::share_co2) datalog_data += "co:" + value + ",";
-            else if (type == "co" && cfg::share_co) datalog_data += "co1:" + value + ",";
+            else if (type == "co2" && cfg::share_co2) datalog_data += "co2:" + value + ",";
+            else if (type == "co" && cfg::share_co) datalog_data += "co:" + value + ",";
             else if (type == "o3" && cfg::share_o3) datalog_data += "o3:" + value + ",";
             else if (type == "no2" && cfg::share_no2) datalog_data += "no2:" + value + ",";
             else if (type == "fast_aqi" && cfg::share_fast_aqi) datalog_data += "fa:" + value + ",";

--- a/defines.h
+++ b/defines.h
@@ -117,8 +117,8 @@ constexpr const unsigned long WIFI_STA_REBOOT_AFTER_MS = (30UL * 60UL * 1000UL);
 // ------------------------------------------------------------
 // Urban TTL constants (Insight only)
 // ------------------------------------------------------------
-constexpr const uint32_t URBAN_STALE_AFTER_MS   = 6UL * 60UL * 1000UL;   // ~1 fetch interval + buffer
-constexpr const uint32_t URBAN_OFFLINE_AFTER_MS = 10UL * 60UL * 1000UL;  // ~2 fetch intervals
+constexpr const uint32_t URBAN_STALE_AFTER_MS   = 10UL * 60UL * 1000UL;   // ~1 fetch interval + buffer
+constexpr const uint32_t URBAN_OFFLINE_AFTER_MS = 20UL * 60UL * 1000UL;  // ~2 fetch intervals
 /** Consecutive UI/LED evaluation cycles in the stale window before showing stale (reduces flicker). */
 constexpr const uint8_t URBAN_STALE_CONFIRMATIONS_REQUIRED = 3;
 constexpr const unsigned long URBAN_REDISCOVER_INTERVAL_MS = 5UL * 60UL * 1000UL;

--- a/display/screens/main_screen.cpp
+++ b/display/screens/main_screen.cpp
@@ -359,6 +359,7 @@ int co2DangerDirection(float co2) {
 // Extract main screen values directly from shared sensors data.
 // This avoids serialize->deserialize on every refresh.
 void extractMainScreenValues(const JsonDocument &doc, main_screen_values_t &values) {
+    values = main_screen_values_t{};
     values.wifi_sta_link_ok = wifiStaLinkReady();
     JsonObjectConst data = doc.as<JsonObjectConst>();
     String urban_key = ATRUIST_URBAN_SENSOR;

--- a/leds/leds_controller_urban.cpp
+++ b/leds/leds_controller_urban.cpp
@@ -5,107 +5,101 @@
 #include "../utils.h"
 #include "../config_manager/config_helpers.h"
 
-#define LED_NUM_DATA_SENDING 0
-#define LED_NUM_CONNECTION 1
-
 LedControllerUrban::LedControllerUrban():
-    pixels(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800) {}
+    pixels(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800),
+    board_pixels(URBAN_BOARD_RGB_LED_COUNT, URBAN_BOARD_RGB_LED_PIN, NEO_GRB + NEO_KHZ800) {}
 
 void LedControllerUrban::init() {
+    uint8_t brightness = cfg::leds_brightness * 255 / 100;
     if (LED_PIN != -1 && cfg::leds_on) {
         pixels.begin();
         pixels.clear();
-        uint8_t brightness;
-        if (cfg::leds_brightness * 255 / 100 < 0) {
-            brightness = 0;
-        } else if (cfg::leds_brightness * 255 / 100 > 255) {
-            brightness = 255;
-        } else {
-            brightness = cfg::leds_brightness * 255 / 100;
-        }
         pixels.setBrightness(brightness);
         pixels.show();
         debug_outln_info(F("Setup leds on pin "), LED_PIN);
     } else {
         debug_outln_info(F("Will not setup leds on pin "), LED_PIN);
     }
+    if (_hasBoardRgbLed()) {
+        board_pixels.begin();
+        board_pixels.clear();
+        board_pixels.setBrightness(brightness);
+        board_pixels.show();
+        debug_outln_info(F("Setup board RGB led on pin "), String(URBAN_BOARD_RGB_LED_PIN));
+    }
 }
 
 void LedControllerUrban::setMode(LedMode mode) {
+    if (current_mode == mode && !mode_changed) {
+        return;
+    }
     mode_changed = true;
     current_mode = mode;
+    debug_outln_info(F("[Urban LED] mode: "), _modeName(mode));
 }
 
 void LedControllerUrban::process() {
     if (LED_PIN == -1 || !cfg::leds_on) {
         return;
     }
-    if (mode_changed) {
-        mode_changed = false;
-        switch (current_mode) {
-            case LedMode::NONE:
-                pixels.clear();
-                connection_color_set = false;
-                break;
-            case LedMode::BLUE:
-                connection_color = pixels.Color(0, 0, 255);
-                connection_color_set = true;
-                pixels.setPixelColor(LED_NUM_CONNECTION, connection_color);
-                break;
-            case LedMode::GREEN:
-                connection_color = pixels.Color(0, 255, 0);
-                connection_color_set = true;
-                pixels.setPixelColor(LED_NUM_CONNECTION, connection_color);
-                break;
-            case LedMode::PROVISIONING:
-                // Purple: AP/provisioning mode
-                connection_color = pixels.Color(160, 0, 255);
-                connection_color_set = true;
-                pixels.setPixelColor(LED_NUM_CONNECTION, connection_color);
-                break;
-            case LedMode::RESETTING:
-                // Yellow: reset in progress (both LEDs)
-                connection_color = pixels.Color(255, 200, 0);
-                connection_color_set = true;
-                pixels.setPixelColor(LED_NUM_CONNECTION, connection_color);
-                pixels.setPixelColor(LED_NUM_DATA_SENDING, connection_color);
-                break;
-            case LedMode::BLINK_RED:
-                // Keep connection LED as-is; blink only the data LED.
-                if (connection_color_set) {
-                    pixels.setPixelColor(LED_NUM_CONNECTION, connection_color);
-                }
-                for (int blink_count = 0; blink_count < MAX_BLINK_COUNT; blink_count++) {
-                    pixels.setPixelColor(LED_NUM_DATA_SENDING, pixels.Color(255, 0, 0));
-                    pixels.show();
-                    delay(150);
-                    pixels.setPixelColor(LED_NUM_DATA_SENDING, pixels.Color(0, 0, 0));
-                    pixels.show();
-                    delay(150);
-                }
-                break;
-            case LedMode::BLINK_GREEN:
-                // Keep connection LED as-is; blink only the data LED.
-                if (connection_color_set) {
-                    pixels.setPixelColor(LED_NUM_CONNECTION, connection_color);
-                }
-                for (int blink_count = 0; blink_count < MAX_BLINK_COUNT; blink_count++) {
-                    pixels.setPixelColor(LED_NUM_DATA_SENDING, pixels.Color(0, 255, 0));
-                    pixels.show();
-                    delay(150);
-                    pixels.setPixelColor(LED_NUM_DATA_SENDING, pixels.Color(0, 0, 0));
-                    pixels.show();
-                    delay(150);
-                }
-                break;
-        }
-        pixels.show();
+    mode_changed = false;
+    switch (current_mode) {
+        case LedMode::NONE:
+            pixels.clear();
+            if (_hasBoardRgbLed()) {
+                board_pixels.clear();
+            }
+            break;
+        case LedMode::BLUE:
+        case LedMode::PROVISIONING:
+        case LedMode::RESETTING:
+            _setSolidColor(0, 0, 255);
+            break;
+        case LedMode::GREEN:
+            _setSolidColor(0, 255, 0);
+            break;
+        case LedMode::RED:
+            _setSolidColor(255, 0, 0);
+            break;
     }
+    pixels.show();
+    if (_hasBoardRgbLed()) {
+        board_pixels.show();
+    }
+}
+
+bool LedControllerUrban::_hasBoardRgbLed() {
+    return cfg::leds_on && URBAN_BOARD_RGB_LED_PIN != -1 && URBAN_BOARD_RGB_LED_PIN != LED_PIN;
+}
+
+String LedControllerUrban::_modeName(LedMode mode) {
+    switch (mode) {
+        case LedMode::NONE:
+            return F("NONE");
+        case LedMode::BLUE:
+            return F("BLUE");
+        case LedMode::PROVISIONING:
+            return F("PROVISIONING");
+        case LedMode::RESETTING:
+            return F("RESETTING");
+        case LedMode::GREEN:
+            return F("GREEN");
+        case LedMode::RED:
+            return F("RED");
+    }
+    return F("UNKNOWN");
+}
+
+void LedControllerUrban::_setSolidColor(uint8_t red, uint8_t green, uint8_t blue) {
+    _setAllPixels(pixels.Color(red, green, blue));
 }
 
 void LedControllerUrban::_setAllPixels(uint32_t color) {
     for (int pixel = 0; pixel < LED_COUNT; pixel++) {
         pixels.setPixelColor(pixel, color);
+    }
+    if (_hasBoardRgbLed()) {
+        board_pixels.setPixelColor(0, color);
     }
 }
 

--- a/leds/leds_controller_urban.h
+++ b/leds/leds_controller_urban.h
@@ -7,16 +7,20 @@
 #include <Adafruit_NeoPixel.h>
 
 #define LED_COUNT 2
-#define MAX_BLINK_COUNT 1
+#if defined(CONFIG_IDF_TARGET_ESP32C6)
+#define URBAN_BOARD_RGB_LED_PIN 8
+#else
+#define URBAN_BOARD_RGB_LED_PIN -1
+#endif
+#define URBAN_BOARD_RGB_LED_COUNT 1
 
 enum class LedMode {
     NONE,
-    BLINK_RED,
     BLUE,
     PROVISIONING,
     RESETTING,
-    BLINK_GREEN,
-    GREEN
+    GREEN,
+    RED
 };
 
 class LedControllerUrban {
@@ -30,9 +34,11 @@ class LedControllerUrban {
         LedMode current_mode = LedMode::NONE;
         bool mode_changed = false;
         Adafruit_NeoPixel pixels;
-        uint32_t connection_color = 0;
-        bool connection_color_set = false;
+        Adafruit_NeoPixel board_pixels;
 
+        bool _hasBoardRgbLed();
+        String _modeName(LedMode mode);
+        void _setSolidColor(uint8_t red, uint8_t green, uint8_t blue);
         void _setAllPixels(uint32_t color);
 };
 

--- a/sensors/http_altruist_sensor.cpp
+++ b/sensors/http_altruist_sensor.cpp
@@ -240,6 +240,8 @@ void HTTPAltruistSensor::_fetch_one_sensor(JsonDocument &data, HTTPClient& http,
         debug_outln_verbose(F("HTTPAltruistSensor: sensordatavalues count "),
                          String(values.size()));
 
+        bool seen_sds_p1 = false;
+        bool seen_sds_p2 = false;
         for (JsonObject v : values) {
             String type  = v["value_type"];
             float  value = v["value"].as<float>();
@@ -248,9 +250,11 @@ void HTTPAltruistSensor::_fetch_one_sensor(JsonDocument &data, HTTPClient& http,
             String units;
             String intl_name;
             if (type == "SDS_P1") {
+                seen_sds_p1 = true;
                 intl_name = "PM10";
                 units = F("µg/m³");
             } else if (type == "SDS_P2") {
+                seen_sds_p2 = true;
                 intl_name = "PM2.5";
                 units = F("µg/m³");
             } else if (type == "BME280_temperature") {
@@ -281,6 +285,12 @@ void HTTPAltruistSensor::_fetch_one_sensor(JsonDocument &data, HTTPClient& http,
             measObj[F("value")]     = value;
             measObj[F("intl_name")] = intl_name;
             measObj[F("units")]     = units;
+        }
+        if (!seen_sds_p1) {
+            urbanRoot.remove("SDS_P1");
+        }
+        if (!seen_sds_p2) {
+            urbanRoot.remove("SDS_P2");
         }
         // Mark JSON as updated so SD card logger (and graph data) see Urban data
         _jsonUpdated = true;

--- a/sensors/sds011_sensor.cpp
+++ b/sensors/sds011_sensor.cpp
@@ -12,7 +12,6 @@ enum {
 	SDS_REPLY_BODY = 8
 } SDS_waiting_for;
 
-/** Consecutive measurement windows with no valid samples → UART/protocol recover (issue #110). */
 static constexpr uint8_t kSdsRecoverAfterBadWindows = 3;
 
 SDS011Sensor::SDS011Sensor(unsigned long sending_timeout)
@@ -41,7 +40,9 @@ bool SDS011Sensor::begin() {
 }
 
 void SDS011Sensor::sdsUartRecover() {
+	sds_recovery_count++;
 	debug_outln_info(F("[SDS011] recover: drain UART, re-init, idle cycle"));
+	debug_outln_info(F("[SDS011] recovery count: "), String(sds_recovery_count));
 	while (serialSDS.available()) {
 		(void)serialSDS.read();
 	}
@@ -193,7 +194,7 @@ bool SDS011Sensor::checksum_valid(const uint8_t (&data)[8]) {
     return (data[7] == 0xAB && checksum_is == data[6]);
 }
 
-void SDS011Sensor::rawcmd(const uint8_t cmd_head1, const uint8_t cmd_head2, const uint8_t cmd_head3) {
+bool SDS011Sensor::rawcmd(const uint8_t cmd_head1, const uint8_t cmd_head2, const uint8_t cmd_head3) {
 	constexpr uint8_t cmd_len = 19;
 
 	uint8_t buf[cmd_len];
@@ -209,23 +210,29 @@ void SDS011Sensor::rawcmd(const uint8_t cmd_head1, const uint8_t cmd_head2, cons
 	buf[16] = 0xFF;
 	buf[17] = cmd_head1 + cmd_head2 + cmd_head3 - 2;
 	buf[18] = 0xAB;
-	serialSDS.write(buf, cmd_len);
+	const size_t written = serialSDS.write(buf, cmd_len);
+	if (written != cmd_len) {
+		debug_outln_error(F("[SDS011] command write failed"));
+		return false;
+	}
+	return true;
 }
 
 bool SDS011Sensor::cmd(PmSensorCmd cmd) {
+	bool write_ok = true;
 	switch (cmd) {
 	case PmSensorCmd::Start:
-		rawcmd(0x06, 0x01, 0x01);
+		write_ok = rawcmd(0x06, 0x01, 0x01);
 		break;
 	case PmSensorCmd::Stop:
-		rawcmd(0x06, 0x01, 0x00);
+		write_ok = rawcmd(0x06, 0x01, 0x00);
 		break;
 	case PmSensorCmd::ContinuousMode:
 		// TODO: Check mode first before (re-)setting it
-		rawcmd(0x08, 0x01, 0x00);
-		rawcmd(0x02, 0x01, 0x00);
+		write_ok = rawcmd(0x08, 0x01, 0x00);
+		write_ok = rawcmd(0x02, 0x01, 0x00) && write_ok;
 		break;
 	}
 
-	return cmd != PmSensorCmd::Stop;
+	return write_ok && cmd != PmSensorCmd::Stop;
 }

--- a/sensors/sds011_sensor.h
+++ b/sensors/sds011_sensor.h
@@ -26,6 +26,7 @@ private:
     void sdsUartRecover();
     unsigned long SDS_error_count = 0;
     uint8_t sds_bad_window_streak = 0;
+    uint16_t sds_recovery_count = 0;
     uint32_t sds_pm10_sum = 0;
     uint32_t sds_pm25_sum = 0;
     uint32_t sds_val_count = 0;
@@ -39,7 +40,7 @@ private:
     bool is_SDS_running = false;
     String last_value_SDS_version;
     bool checksum_valid(const uint8_t (&data)[8]);
-    void rawcmd(const uint8_t cmd_head1, const uint8_t cmd_head2, const uint8_t cmd_head3);
+    bool rawcmd(const uint8_t cmd_head1, const uint8_t cmd_head2, const uint8_t cmd_head3);
     bool cmd(PmSensorCmd cmd);
     String version_date();
 };


### PR DESCRIPTION
- **Renamed Robonomics datalog keys for CO and CO2** :
  - co2 -> co2
  - co -> co
  
- **SDS011 runtime recovery** — added detection of consecutive empty SDS011 measurement windows and UART/protocol recovery without reboot (drain UART, reinitialize Serial1 on ESP32, reset parser state, and restart the measurement cycle).


- **Urban LED states** — simplified Urban LED behavior: steady green for normal operation, blue for configuration mode and active datalog sending, 3-second green/red result after datalog transmission, and steady red only after sustained Wi-Fi/API errors.