### PR TITLE
feat: Improv Wi-Fi Serial protocol for web-based provisioning

### DIFF
--- a/airrohr-firmware.ino
+++ b/airrohr-firmware.ino
@@ -97,6 +97,7 @@
 #include "apis/apis.h"
 #include "config_manager/config_helpers.h"
 #include "wifi_manager.h"
+#include "improv/improv_serial.h"
 #include "webserver/webserver.h"
 #include "OTA_Update.h"
 #if defined(USE_SD_CARD)
@@ -1135,6 +1136,20 @@ void setup(void) {
 	#endif
 	delay(200);
 
+	improv_serial_setup();
+	improv_set_wifi_callback(wifiApplyImprovCredentials);
+	improv_set_rws_owner_callback([](const String& owner) {
+		owner.toCharArray(cfg::rws_owner, LEN_RWS_OWNER);
+		writeConfig();
+		debug_outln_info(F("[IMPROV] rws_owner saved: "), owner);
+	});
+
+	// Give Improv Serial time to receive and respond to initial queries from webflasher.
+	for (int i = 0; i < 30; i++) {
+		improv_serial_loop();
+		delay(100);
+	}
+
 	// If button(s) pressed while turning on, factory-reset configuration (Insight / Urban C6 HW).
 #if defined(ALTRUIST_INSIDE) || defined(ALTRUIST_URBAN_HW_UI)
 #ifdef ALTRUIST_URBAN_HW_UI
@@ -1510,6 +1525,7 @@ void loop(void) {
 	if (!wifiIsConfigPortalRunning()) {
 		webserver.handleClient();
 	}
+	improv_serial_loop();
 #if defined(ALTRUIST_INSIDE)
 	markCrashSection(CRASH_SECTION_DISPLAY_UPDATE);
 	displayManager.process(btn_press);

--- a/airrohr-firmware.ino
+++ b/airrohr-firmware.ino
@@ -1145,10 +1145,12 @@ void setup(void) {
 	});
 
 	// Give Improv Serial time to receive and respond to initial queries from webflasher.
+	// Announce AUTHORIZED state periodically so webflasher detects the device even on late connect.
 	for (int i = 0; i < 30; i++) {
 		improv_serial_loop();
 		delay(100);
 	}
+	improv_start_announce(20);
 
 	// If button(s) pressed while turning on, factory-reset configuration (Insight / Urban C6 HW).
 #if defined(ALTRUIST_INSIDE) || defined(ALTRUIST_URBAN_HW_UI)

--- a/improv/improv_serial.cpp
+++ b/improv/improv_serial.cpp
@@ -40,6 +40,9 @@ static ImprovRwsOwnerCallback s_rws_owner_cb = nullptr;
 static uint8_t s_improv_buf[256];
 static size_t s_improv_pos = 0;
 static uint8_t s_improv_state = IMPROV_STATE_STOPPED;
+static uint8_t s_improv_announce_remaining = 0;
+static unsigned long s_improv_last_announce_ms = 0;
+static constexpr unsigned long IMPROV_ANNOUNCE_INTERVAL_MS = 500;
 
 static void improv_send_error(uint8_t error);
 
@@ -62,6 +65,10 @@ static void improv_send_state(uint8_t state) {
 void improv_set_state(uint8_t state) {
     s_improv_state = state;
     improv_send_state(state);
+}
+
+void improv_start_announce(uint8_t count) {
+    s_improv_announce_remaining = count;
 }
 
 void improv_set_error(uint8_t error) {
@@ -225,8 +232,19 @@ void improv_serial_setup() {
 }
 
 void improv_serial_loop() {
+    if (s_improv_announce_remaining > 0 && s_improv_state != IMPROV_STATE_STOPPED) {
+        unsigned long now = millis();
+        if (now - s_improv_last_announce_ms >= IMPROV_ANNOUNCE_INTERVAL_MS) {
+            improv_send_state(s_improv_state);
+            s_improv_announce_remaining--;
+            s_improv_last_announce_ms = now;
+        }
+    }
     while (Serial.available()) {
         uint8_t byte = Serial.read();
+        if (s_improv_pos == 0 && byte == 'I') {
+            s_improv_announce_remaining = 0;
+        }
         if (s_improv_pos == 0 && byte != 'I') continue;
         if (s_improv_pos == 1 && byte != 'M') { s_improv_pos = 0; continue; }
         if (s_improv_pos == 2 && byte != 'P') { s_improv_pos = 0; continue; }

--- a/improv/improv_serial.cpp
+++ b/improv/improv_serial.cpp
@@ -1,0 +1,279 @@
+#include "improv_serial.h"
+#include "../defines.h"
+#include <WiFi.h>
+#include <cstring>
+
+#define IMPROV_SERIAL_VERSION 1
+
+#define IMPROV_TYPE_CURRENT_STATE 0x01
+#define IMPROV_TYPE_ERROR_STATE 0x02
+#define IMPROV_TYPE_RPC 0x03
+#define IMPROV_TYPE_RPC_RESPONSE 0x04
+
+#define IMPROV_CMD_WIFI_SETTINGS 0x01
+#define IMPROV_CMD_IDENTIFY 0x02
+#define IMPROV_CMD_GET_CURRENT_STATE 0x02
+#define IMPROV_CMD_GET_DEVICE_INFO 0x03
+#define IMPROV_CMD_GET_WIFI_NETWORKS 0x04
+#define IMPROV_CMD_HOSTNAME 0x05
+#define IMPROV_CMD_DEVICE_NAME 0x06
+#define IMPROV_CMD_BAD_CHECKSUM 0xFF
+#define IMPROV_CMD_CUSTOM_RWS_OWNER 0x80
+
+#define IMPROV_STATE_STOPPED 0x00
+#define IMPROV_STATE_AWAITING_AUTH 0x01
+#define IMPROV_STATE_AUTHORIZED 0x02
+#define IMPROV_STATE_PROVISIONING 0x03
+#define IMPROV_STATE_PROVISIONED 0x04
+
+#define IMPROV_ERROR_NONE 0x00
+#define IMPROV_ERROR_INVALID_RPC 0x01
+#define IMPROV_ERROR_UNKNOWN_RPC 0x02
+#define IMPROV_ERROR_UNABLE_TO_CONNECT 0x03
+#define IMPROV_ERROR_NOT_AUTHORIZED 0x04
+#define IMPROV_ERROR_UNKNOWN 0xFF
+
+static const char* const IMPROV_TAG = "[IMPROV]";
+
+static ImprovWifiCallback s_wifi_cb = nullptr;
+static ImprovRwsOwnerCallback s_rws_owner_cb = nullptr;
+static uint8_t s_improv_buf[256];
+static size_t s_improv_pos = 0;
+static uint8_t s_improv_state = IMPROV_STATE_STOPPED;
+
+static void improv_send_error(uint8_t error);
+
+static void improv_send_state(uint8_t state) {
+    uint8_t checksum = 'I' + 'M' + 'P' + 'R' + 'O' + 'V' + IMPROV_SERIAL_VERSION;
+    checksum += IMPROV_TYPE_CURRENT_STATE;
+    checksum += 1;
+    checksum += state;
+    Serial.write('I'); Serial.write('M'); Serial.write('P');
+    Serial.write('R'); Serial.write('O'); Serial.write('V');
+    Serial.write(IMPROV_SERIAL_VERSION);
+    Serial.write(IMPROV_TYPE_CURRENT_STATE);
+    Serial.write(1);
+    Serial.write(state);
+    Serial.write(checksum);
+    Serial.write('\n');
+    Serial.flush();
+}
+
+void improv_set_state(uint8_t state) {
+    s_improv_state = state;
+    improv_send_state(state);
+}
+
+void improv_set_error(uint8_t error) {
+    improv_send_error(error);
+}
+
+static void improv_send_error(uint8_t error) {
+    uint8_t checksum = 'I' + 'M' + 'P' + 'R' + 'O' + 'V' + IMPROV_SERIAL_VERSION;
+    checksum += IMPROV_TYPE_ERROR_STATE;
+    checksum += 1;
+    checksum += error;
+    Serial.write('I'); Serial.write('M'); Serial.write('P');
+    Serial.write('R'); Serial.write('O'); Serial.write('V');
+    Serial.write(IMPROV_SERIAL_VERSION);
+    Serial.write(IMPROV_TYPE_ERROR_STATE);
+    Serial.write(1);
+    Serial.write(error);
+    Serial.write(checksum);
+    Serial.write('\n');
+    Serial.flush();
+}
+
+static void improv_send_rpc_response(uint8_t cmd, const std::vector<String>& datum) {
+    size_t strings_len = 0;
+    for (const auto& s : datum) {
+        strings_len += 1 + s.length();
+    }
+    if (strings_len + 2 + 10 > 256) return;
+
+    uint8_t buf[256];
+    buf[0] = 'I'; buf[1] = 'M'; buf[2] = 'P'; buf[3] = 'R'; buf[4] = 'O'; buf[5] = 'V';
+    buf[6] = IMPROV_SERIAL_VERSION;
+    buf[7] = IMPROV_TYPE_RPC_RESPONSE;
+
+    size_t pos = 9;
+    buf[pos++] = cmd;
+    buf[pos++] = (uint8_t)strings_len;
+    for (const auto& s : datum) {
+        buf[pos++] = (uint8_t)s.length();
+        memcpy(buf + pos, s.c_str(), s.length());
+        pos += s.length();
+    }
+    buf[8] = (uint8_t)(pos - 9);
+
+    uint32_t checksum = 0;
+    for (size_t i = 0; i < pos; i++) checksum += buf[i];
+    buf[pos] = (uint8_t)(checksum & 0xFF);
+    pos++;
+
+    Serial.write(buf, pos);
+    Serial.write('\n');
+    Serial.flush();
+}
+
+void improv_send_response(const std::vector<String>& datum) {
+    improv_send_rpc_response(IMPROV_CMD_WIFI_SETTINGS, datum);
+}
+
+static void improv_handle_rpc(const uint8_t* data, size_t len) {
+    if (len < 1) {
+        improv_send_error(IMPROV_ERROR_INVALID_RPC);
+        return;
+    }
+
+    uint8_t cmd = data[0];
+
+    if (cmd == IMPROV_CMD_GET_CURRENT_STATE) {
+        improv_set_state(s_improv_state);
+    } else if (cmd == IMPROV_CMD_GET_DEVICE_INFO) {
+        std::vector<String> info;
+        info.push_back(F("Altruist"));
+#ifdef ALTRUIST_INSIDE
+        info.push_back(F("Altruist-Insight"));
+#else
+        info.push_back(F("Altruist-Urban"));
+#endif
+        info.push_back(String(SOFTWARE_VERSION_STR));
+        info.push_back(F("altruist-firmware"));
+        improv_send_rpc_response(IMPROV_CMD_GET_DEVICE_INFO, info);
+    } else if (cmd == IMPROV_CMD_GET_WIFI_NETWORKS) {
+        int8_t count = WiFi.scanNetworks(false, true);
+        for (int8_t i = 0; i < count && i < 15; i++) {
+            std::vector<String> net;
+            net.push_back(WiFi.SSID(i));
+            net.push_back(String(WiFi.RSSI(i)));
+            net.push_back(WiFi.encryptionType(i) != WIFI_AUTH_OPEN ? "YES" : "NO");
+            improv_send_rpc_response(IMPROV_CMD_GET_WIFI_NETWORKS, net);
+        }
+        WiFi.scanDelete();
+        improv_send_rpc_response(IMPROV_CMD_GET_WIFI_NETWORKS, std::vector<String>());
+    } else if (cmd == IMPROV_CMD_WIFI_SETTINGS) {
+        if (len < 2) {
+            improv_send_error(IMPROV_ERROR_INVALID_RPC);
+            return;
+        }
+        uint8_t payload_len = data[1];
+        if ((size_t)(2 + payload_len) > len) {
+            improv_send_error(IMPROV_ERROR_INVALID_RPC);
+            return;
+        }
+        uint8_t ssid_len = data[2];
+        if ((size_t)(3 + ssid_len) > 2 + payload_len) {
+            improv_send_error(IMPROV_ERROR_INVALID_RPC);
+            return;
+        }
+        String ssid((const char*)(data + 3), ssid_len);
+        uint8_t pwd_len = data[3 + ssid_len];
+        if ((size_t)(4 + ssid_len + pwd_len) > 2 + payload_len) {
+            improv_send_error(IMPROV_ERROR_INVALID_RPC);
+            return;
+        }
+        String password((const char*)(data + 4 + ssid_len), pwd_len);
+
+        improv_set_state(IMPROV_STATE_PROVISIONING);
+        improv_send_rpc_response(IMPROV_CMD_WIFI_SETTINGS, std::vector<String>());
+
+        bool connected = false;
+        if (s_wifi_cb) {
+            connected = s_wifi_cb(ssid, password);
+        }
+
+        if (connected) {
+            improv_set_state(IMPROV_STATE_PROVISIONED);
+            std::vector<String> result;
+            result.push_back(WiFi.localIP().toString());
+            improv_send_rpc_response(IMPROV_CMD_WIFI_SETTINGS, result);
+        } else {
+            improv_set_error(IMPROV_ERROR_UNABLE_TO_CONNECT);
+            improv_set_state(IMPROV_STATE_AUTHORIZED);
+        }
+    } else if (cmd == IMPROV_CMD_CUSTOM_RWS_OWNER) {
+        if (len < 2) {
+            improv_send_error(IMPROV_ERROR_INVALID_RPC);
+            return;
+        }
+        uint8_t payload_len = data[1];
+        if ((size_t)(2 + payload_len) > len) {
+            improv_send_error(IMPROV_ERROR_INVALID_RPC);
+            return;
+        }
+        uint8_t owner_len = data[2];
+        if ((size_t)(3 + owner_len) > 2 + payload_len) {
+            improv_send_error(IMPROV_ERROR_INVALID_RPC);
+            return;
+        }
+        String rws_owner((const char*)(data + 3), owner_len);
+
+        if (s_rws_owner_cb) {
+            s_rws_owner_cb(rws_owner);
+        }
+        improv_send_rpc_response(IMPROV_CMD_CUSTOM_RWS_OWNER, std::vector<String>());
+    } else {
+        improv_send_error(IMPROV_ERROR_UNKNOWN_RPC);
+    }
+}
+
+void improv_serial_setup() {
+    s_improv_pos = 0;
+    s_improv_state = IMPROV_STATE_AUTHORIZED;
+    improv_set_state(IMPROV_STATE_AUTHORIZED);
+}
+
+void improv_serial_loop() {
+    while (Serial.available()) {
+        uint8_t byte = Serial.read();
+        if (s_improv_pos == 0 && byte != 'I') continue;
+        if (s_improv_pos == 1 && byte != 'M') { s_improv_pos = 0; continue; }
+        if (s_improv_pos == 2 && byte != 'P') { s_improv_pos = 0; continue; }
+        if (s_improv_pos == 3 && byte != 'R') { s_improv_pos = 0; continue; }
+        if (s_improv_pos == 4 && byte != 'O') { s_improv_pos = 0; continue; }
+        if (s_improv_pos == 5 && byte != 'V') { s_improv_pos = 0; continue; }
+
+        s_improv_buf[s_improv_pos++] = byte;
+
+        if (s_improv_pos < 7) continue;
+        if (s_improv_pos == 6 && byte != IMPROV_SERIAL_VERSION) {
+            s_improv_pos = 0;
+            continue;
+        }
+
+        uint8_t type = s_improv_buf[7];
+        uint8_t data_len = s_improv_buf[8];
+
+        if (s_improv_pos < 9 + data_len + 1) continue;
+
+        uint8_t checksum = 0;
+        for (size_t i = 0; i < s_improv_pos - 1; i++) checksum += s_improv_buf[i];
+        if (checksum != s_improv_buf[s_improv_pos - 1]) {
+            improv_send_error(IMPROV_ERROR_INVALID_RPC);
+            s_improv_pos = 0;
+            continue;
+        }
+
+        if (s_improv_state == IMPROV_STATE_STOPPED) {
+            s_improv_pos = 0;
+            continue;
+        }
+
+        if (s_improv_state == IMPROV_STATE_AUTHORIZED) {
+            if (type == IMPROV_TYPE_RPC) {
+                improv_handle_rpc(&s_improv_buf[9], data_len);
+            }
+        }
+
+        s_improv_pos = 0;
+    }
+}
+
+void improv_set_wifi_callback(ImprovWifiCallback cb) {
+    s_wifi_cb = cb;
+}
+
+void improv_set_rws_owner_callback(ImprovRwsOwnerCallback cb) {
+    s_rws_owner_cb = cb;
+}

--- a/improv/improv_serial.h
+++ b/improv/improv_serial.h
@@ -15,3 +15,4 @@ void improv_set_rws_owner_callback(ImprovRwsOwnerCallback cb);
 void improv_set_state(uint8_t state);
 void improv_set_error(uint8_t error);
 void improv_send_response(const std::vector<String>& datum);
+void improv_start_announce(uint8_t count);

--- a/improv/improv_serial.h
+++ b/improv/improv_serial.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <Arduino.h>
+#include <functional>
+
+void improv_serial_setup();
+void improv_serial_loop();
+
+using ImprovWifiCallback = std::function<bool(const String& ssid, const String& password)>;
+using ImprovRwsOwnerCallback = std::function<void(const String& rws_owner)>;
+
+void improv_set_wifi_callback(ImprovWifiCallback cb);
+void improv_set_rws_owner_callback(ImprovRwsOwnerCallback cb);
+
+void improv_set_state(uint8_t state);
+void improv_set_error(uint8_t error);
+void improv_send_response(const std::vector<String>& datum);

--- a/wifi_manager.cpp
+++ b/wifi_manager.cpp
@@ -1,5 +1,6 @@
 #include "wifi_manager.h"
 #include "config_manager/config_helpers.h"
+#include "improv/improv_serial.h"
 #include "utils.h"
 #include <WiFi.h>
 #if !defined(ALTRUIST_URBAN_C3_NO_MDNS)
@@ -361,6 +362,7 @@ void wifiConfig(SensorWebServer &webserver) {
 	while (true) {
 		dnsServer.processNextRequest();
 		webserver.handleClient();
+		improv_serial_loop();
 #ifdef ALTRUIST_INSIDE
 		// Process display manager to handle button presses (e.g., sleep mode) even during WiFi config
 		displayManager.process(btn_press);
@@ -412,6 +414,7 @@ void wifiConfig(SensorWebServer &webserver) {
 static void waitForWifiToConnect(unsigned maxDelays, unsigned long interval_ms) {
 	unsigned delays_done = 0;
 	for (;;) {
+		improv_serial_loop();
 		if (wifiStaLinkReady()) {
 			return;
 		}
@@ -513,5 +516,37 @@ bool connectWifi(SensorWebServer &webserver, bool station_join_already_started) 
 	}
 #endif
 	return true;
+}
+
+bool wifiApplyImprovCredentials(const String& ssid, const String& password) {
+	if (ssid.length() == 0 || ssid.length() >= LEN_WLANSSID) {
+		return false;
+	}
+	if (password.length() >= LEN_CFG_PASSWORD) {
+		return false;
+	}
+	ssid.toCharArray(cfg::wlanssid, LEN_WLANSSID);
+	password.toCharArray(cfg::wlanpwd, LEN_CFG_PASSWORD);
+	cfg::wlannopwd = (password.length() == 0);
+	writeConfig();
+
+	debug_outln_info(F("[IMPROV] Connecting to SSID: "), ssid);
+
+	WiFi.mode(WIFI_STA);
+	WiFi.setSleep(false);
+	if (cfg::wlannopwd) {
+		WiFi.begin(cfg::wlanssid);
+	} else {
+		WiFi.begin(cfg::wlanssid, cfg::wlanpwd);
+	}
+
+	waitForWifiToConnect(75, 200);
+	bool connected = wifiStaLinkReady();
+	if (connected) {
+		debug_outln_info(F("[IMPROV] Connected, IP: "), WiFi.localIP().toString());
+	} else {
+		debug_outln_error(F("[IMPROV] Failed to connect"));
+	}
+	return connected;
 }
 

--- a/wifi_manager.cpp
+++ b/wifi_manager.cpp
@@ -532,6 +532,8 @@ bool wifiApplyImprovCredentials(const String& ssid, const String& password) {
 
 	debug_outln_info(F("[IMPROV] Connecting to SSID: "), ssid);
 
+	WiFi.disconnect(true, false);
+	delay(150);
 	WiFi.mode(WIFI_STA);
 	WiFi.setSleep(false);
 	if (cfg::wlannopwd) {

--- a/wifi_manager.h
+++ b/wifi_manager.h
@@ -41,6 +41,13 @@ void wifiRequestPortalExit(void);
  */
 bool wifiFinishCaptivePortalSaveAndRestart(void);
 
+/**
+ * Apply Wi-Fi credentials received via Improv Serial.
+ * Copies SSID/password to config, saves to SPIFFS, and attempts connection.
+ * Returns true if STA successfully connected with the new credentials.
+ */
+bool wifiApplyImprovCredentials(const String& ssid, const String& password);
+
 #if defined(ESP32)
 /** Register WiFi event hooks (STA disconnect → fast reconnect kick). Call once after WiFi.persistent(). */
 void wifiRegisterStaRecoveryEvents(void);


### PR DESCRIPTION

## Summary

Adds [Improv Wi-Fi Serial](https://github.com/improv-wifi/serial-sdk) protocol support, enabling WiFi provisioning via [webflasher](https://webflasher.robonomics.network/) (and any Improv-compatible client).

### What it does

- **Improv Serial protocol** (`improv/`): device announces itself as `AUTHORIZED` over USB serial, allowing webflasher to detect it and offer WiFi setup
- **WiFi credentials provisioning**: webflasher sends SSID + password → device connects → responds with IP address
- **Device info**: reports model name (`Altruist-Insight` / `Altruist-Urban`), firmware version, and custom `rws_owner` field via Improv RPC
- **WiFi scan**: webflasher can request nearby networks list

### Key changes

| File | Description |
|------|-------------|
| `improv/improv_serial.cpp/h` | Full Improv Serial protocol implementation |
| `airrohr-firmware.ino` | Setup: register callbacks, initial 3s Improv poll, announce loop start |
| `wifi_manager.cpp/h` | `wifiApplyImprovCredentials()` — WiFi connect from Improv with clean disconnect + sleep off; `improv_serial_loop()` called in captive portal and main loop |

### Reliability fixes

- **Periodic state announcements** (20 × 500 ms after boot) ensure webflasher detects the device even on late serial connection
- **Announce stops immediately** when webflasher sends first byte → prevents frame interleaving and `INVALID_RPC` errors
- **`WiFi.disconnect(true, false)` + 150 ms delay** before `WiFi.begin()` in Improv callback ensures clean WiFi state transition

### Testing

Flashed on **Altruist Insight (ESP32-C6)** — `esp32c6_inside_en` environment:
1. Open [webflasher.robonomics.network](https://webflasher.robonomics.network/)
2. Connect device via USB
3. Webflasher detects the device and shows WiFi setup button
4. Enter SSID/password → device connects and reports IP

### Build environments affected

- `esp32c6_inside_en` / `esp32c6_inside_ru` (Insight)
- `esp32c6_urban_en` / `esp32c6_urban_ru` / `_dev` variants
- `esp32c3_urban_en` / `esp32c3_urban_ru` (Urban C3)
