### PR TITLE
Add stable UART diagnostics for Altruist tester

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -117,7 +117,7 @@ The firmware has three independent logging layers:
 1. **Project logs** use `debug_outln_error`, `debug_outln_info`, and
    `debug_outln_verbose` from `utils.cpp`. `ALTRUIST_DEFAULT_LOG_LEVEL` initializes
    `cfg::debug`, while `ALTRUIST_FORCE_LOG_LEVEL` sets its minimum effective value.
-   Testing release builds force level 3 for tester-oriented info/error logs.
+   Stable and Testing release builds use the same runtime logging behavior.
    Debug builds force level 4, so an older saved configuration cannot suppress
    verbose project diagnostics.
 2. **Arduino core logs** are controlled at compile time by `CORE_DEBUG_LEVEL`.
@@ -658,8 +658,8 @@ pio run -e esp32c3_urban_ru_debug -t upload
 1. **Логи проекта** используют `debug_outln_error`, `debug_outln_info` и
    `debug_outln_verbose` из `utils.cpp`. `ALTRUIST_DEFAULT_LOG_LEVEL` задает
    начальное значение `cfg::debug`, а `ALTRUIST_FORCE_LOG_LEVEL` — минимальный
-   эффективный уровень. Testing release-сборки принудительно держат уровень 3
-   для info/error логов тестера. В Debug-сборках уровень 4 принудителен,
+   эффективный уровень. Stable и Testing release-сборки используют одинаковое
+   runtime-поведение логирования. В Debug-сборках уровень 4 принудителен,
    поэтому старое сохраненное значение не может отключить подробные
    диагностические сообщения.
 2. **Логи Arduino core** управляются compile-time флагом `CORE_DEBUG_LEVEL`.

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -166,6 +166,17 @@ saved configuration has been loaded:
 Here `configured` is the persisted `cfg::debug`, `forced` is the compile-time
 minimum, and `runtime` is the effective project log level.
 
+Sensor upload payloads emit a shared machine-readable snapshot before they are
+signed and sent:
+
+```text
+[PAYLOAD] channel=datalog data=h:65.15,t:25.84,p:99860.91,nm:75,na:75
+[PAYLOAD] channel=connectivity data=h:65.15,t:25.84,p:99860.91,nm:75,na:75
+```
+
+The payload line is useful for tester-side sensor value parsing. It does not
+mean that a network upload has succeeded.
+
 On-chain Robonomics datalog sends emit stable machine-readable UART events:
 
 ```text
@@ -174,9 +185,25 @@ On-chain Robonomics datalog sends emit stable machine-readable UART events:
 [DATALOG] failed reason=rpc_error code=1010 message=invalid_transaction response_len=111
 ```
 
-`Datalog data: ...` remains the payload/sensor snapshot used by diagnostics.
 The `[DATALOG]` lines describe the actual on-chain send attempt and final
-result. Timestamp/signature internals are verbose-only diagnostics.
+result. Timestamp/signature internals are verbose-only diagnostics where the
+project controls the log output.
+
+Sensors Connectivity uploads emit their own stable machine-readable UART events:
+
+```text
+[CONNECTIVITY] attempt channel=sensors-connectivity seq=12
+[CONNECTIVITY] success channel=sensors-connectivity seq=12 host=example.host code=200
+[CONNECTIVITY] failed channel=sensors-connectivity seq=12 reason=http_error host=example.host code=403 response_len=128
+```
+
+The `[CONNECTIVITY]` lines describe the HTTP upload attempt and final result.
+Legacy `[Map#...]` lines are verbose diagnostics for host selection and HTTP
+details, not the primary parser contract for automated tests.
+
+Some signing/extrinsic lines such as `Signature size: ...` can still be emitted
+directly by `ESPRobonomicsClient`. They are library diagnostics, not part of the
+stable tester contract.
 
 To view these logs live:
 

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -124,9 +124,10 @@ The firmware has three independent logging layers:
    Debug builds set it to 4 and route diagnostics to `Serial` through
    `DEBUG_ESP_PORT`. Precompiled ESP-IDF library logs remain limited by the
    SDK configuration bundled with the Arduino package.
-3. **Health telemetry** is controlled by `ALTRUIST_HEALTH_TELEMETRY`. It is a
-   stable machine-readable snapshot for the tester and does not depend on either
-   project or framework log levels.
+3. **Tester UART contract** uses stable tagged lines such as `[BOOT]`, `[BUILD]`,
+   `[LOG]`, `[HEALTH]`, `[PAYLOAD]`, `[DATALOG]`, `[CONNECTIVITY]`, and
+   `[SUBSYSTEM]`. These lines are printed directly to `Serial` and do not depend
+   on `cfg::debug`, `ALTRUIST_FORCE_LOG_LEVEL`, or framework log levels.
 
 Project log lines are prefixed with a level:
 
@@ -217,15 +218,16 @@ lines:
 [SUBSYSTEM] event subsystem=wifi reason=sta_recovery mode=deep status=6 ip=0.0.0.0
 ```
 
-These lines are printed directly to Serial and are intended for acceptance
-testing. They cover critical storage, sensor payload, Wi-Fi recovery, display,
-configuration, and OTA failures without requiring a `_debug` build.
+Stable tester contract lines are printed directly to Serial and are intended for
+acceptance testing. They cover boot/build identity, health telemetry, payload
+metadata, upload results, and critical storage, sensor payload, Wi-Fi recovery,
+display, configuration, and OTA failures without requiring a `_debug` build.
 
 Release/tester logs should stay small and machine-readable. Keep raw JSON
 snapshots, full HTTP response bodies, signing internals, sensor internals, and
 memory traces behind verbose/debug logging unless they are promoted to a stable
-tagged contract such as `[PAYLOAD]`, `[DATALOG]`, `[CONNECTIVITY]`,
-`[SUBSYSTEM]`, `[BOOT]`, or `[HEALTH]`.
+tagged contract such as `[BOOT]`, `[BUILD]`, `[LOG]`, `[HEALTH]`, `[PAYLOAD]`,
+`[DATALOG]`, `[CONNECTIVITY]`, or `[SUBSYSTEM]`.
 
 Some signing/extrinsic lines such as `Signature size: ...` can still be emitted
 directly by `ESPRobonomicsClient`. They are library diagnostics, not part of the
@@ -672,9 +674,10 @@ pio run -e esp32c3_urban_ru_debug -t upload
    Debug-сборки задают уровень 4 и направляют вывод в `Serial` через
    `DEBUG_ESP_PORT`. Логи precompiled ESP-IDF библиотек остаются ограничены
    SDK-конфигурацией, поставляемой вместе с Arduino package.
-3. **Health telemetry** управляется `ALTRUIST_HEALTH_TELEMETRY`. Это стабильная,
-   машиночитаемая строка для тестера, не зависящая от уровней логов проекта и
-   фреймворка.
+3. **UART-контракт тестера** использует стабильные tagged-строки: `[BOOT]`,
+   `[BUILD]`, `[LOG]`, `[HEALTH]`, `[PAYLOAD]`, `[DATALOG]`, `[CONNECTIVITY]` и
+   `[SUBSYSTEM]`. Эти строки печатаются напрямую в `Serial` и не зависят от
+   `cfg::debug`, `ALTRUIST_FORCE_LOG_LEVEL` или уровней логов фреймворка.
 
 Строки логов проекта имеют префикс уровня:
 
@@ -704,15 +707,17 @@ release-level формате:
 [SUBSYSTEM] event subsystem=wifi reason=sta_recovery mode=deep status=6 ip=0.0.0.0
 ```
 
-Эти строки печатаются напрямую в Serial и предназначены для приемочного тестера.
-Они покрывают критичные ошибки SD/config, sensor payload, Wi-Fi recovery,
-display и OTA без необходимости собирать `_debug` прошивку.
+Стабильные строки контракта тестера печатаются напрямую в Serial и предназначены
+для приемочного тестера. Они покрывают boot/build identity, health telemetry,
+payload metadata, результаты отправки и критичные ошибки SD/config, sensor
+payload, Wi-Fi recovery, display и OTA без необходимости собирать `_debug`
+прошивку.
 
 Release/tester логи должны оставаться короткими и машинно-читаемыми. Сырые JSON
 snapshots, полные HTTP response bodies, детали подписи, sensor internals и memory
 traces нужно держать за verbose/debug логированием, если они не оформлены как
-стабильный tagged-контракт: `[PAYLOAD]`, `[DATALOG]`, `[CONNECTIVITY]`,
-`[SUBSYSTEM]`, `[BOOT]` или `[HEALTH]`.
+стабильный tagged-контракт: `[BOOT]`, `[BUILD]`, `[LOG]`, `[HEALTH]`,
+`[PAYLOAD]`, `[DATALOG]`, `[CONNECTIVITY]` или `[SUBSYSTEM]`.
 
 После загрузки сохраненной конфигурации прошивка сообщает фактически применяемые
 уровни:

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -135,15 +135,26 @@ Project log lines are prefixed with a level:
 
 Each line also contains a millisecond timestamp in square brackets (time since boot). See the Quick Start section above for example output.
 
+Every boot emits one stable UART boot snapshot before Wi-Fi and sensor startup:
+
+```text
+[BOOT] reset_reason=power_on_reset reset_code=1 boot=4 crash_valid=0 prev_uptime=0 prev_heap=0 last_section_id=0 last_section=Idle/MainLoop heap=219584
+```
+
+This line is intended for automated testers. It is printed directly to Serial
+and does not depend on the saved runtime project log level.
+
 Builds with `ALTRUIST_HEALTH_TELEMETRY` emit a stable UART health snapshot once
 per minute:
 
 ```text
-[HEALTH] uptime=3600 boot=4 heap=219584 rssi=-62 tx=12 errors=0 wifi=1 wifi_errors=0 sensor_errors=0 sd_errors=0
+[HEALTH] uptime=3600 boot=4 heap=219584 rssi=-62 tx=12 errors=0 wifi=1 wifi_errors=0 sensor_errors=0 sd_errors=0 reset_reason=power_on_reset reset_code=1 crash_valid=0 prev_uptime=0 prev_heap=0 last_section_id=0 last_section=Idle/MainLoop
 ```
 
 The initial fields are kept stable for simple parsers. The trailing fields add
-the Wi-Fi link state and per-subsystem error counters for diagnostics.
+the Wi-Fi link state, per-subsystem error counters, and the boot/reset context
+captured at startup. This lets automated testers recover reset diagnostics even
+when they start after the one-time `[BOOT]` line has already been printed.
 
 At boot, firmware reports the effective project and framework levels after the
 saved configuration has been loaded:
@@ -231,6 +242,17 @@ Examples of important SD‑logged messages:
   - `[SDCardLogger]` messages when the card is inserted/removed or when write errors happen. Card type is logged only when it changes or on error, to avoid log spam.
 
 ### 5. Crash and reset diagnostics (boot logs)
+
+On UART, each boot starts with a compact machine-readable `[BOOT]` line:
+
+```text
+[BOOT] reset_reason=task_watchdog_timeout reset_code=6 boot=12 crash_valid=1 prev_uptime=86370 prev_heap=218400 last_section_id=2 last_section=RobonomicsDatalog heap=219584
+```
+
+The UART line lets a tester detect resets and watchdog/brownout/panic recovery
+without reading the SD card. `reset_reason` is a lowercase token, `reset_code`
+is the ESP reset reason code, and `crash_valid=1` means the previous run left
+NVS breadcrumbs.
 
 On every boot the firmware writes a short report to `/exceptions/boot_*.txt` that includes:
 

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -117,8 +117,9 @@ The firmware has three independent logging layers:
 1. **Project logs** use `debug_outln_error`, `debug_outln_info`, and
    `debug_outln_verbose` from `utils.cpp`. `ALTRUIST_DEFAULT_LOG_LEVEL` initializes
    `cfg::debug`, while `ALTRUIST_FORCE_LOG_LEVEL` sets its minimum effective value.
+   Testing release builds force level 3 for tester-oriented info/error logs.
    Debug builds force level 4, so an older saved configuration cannot suppress
-   project diagnostics.
+   verbose project diagnostics.
 2. **Arduino core logs** are controlled at compile time by `CORE_DEBUG_LEVEL`.
    Debug builds set it to 4 and route diagnostics to `Serial` through
    `DEBUG_ESP_PORT`. Precompiled ESP-IDF library logs remain limited by the
@@ -638,8 +639,10 @@ pio run -e esp32c3_urban_ru_debug -t upload
 1. **Логи проекта** используют `debug_outln_error`, `debug_outln_info` и
    `debug_outln_verbose` из `utils.cpp`. `ALTRUIST_DEFAULT_LOG_LEVEL` задает
    начальное значение `cfg::debug`, а `ALTRUIST_FORCE_LOG_LEVEL` — минимальный
-   эффективный уровень. В Debug-сборках уровень 4 принудителен, поэтому старое
-   сохраненное значение не может отключить диагностические сообщения.
+   эффективный уровень. Testing release-сборки принудительно держат уровень 3
+   для info/error логов тестера. В Debug-сборках уровень 4 принудителен,
+   поэтому старое сохраненное значение не может отключить подробные
+   диагностические сообщения.
 2. **Логи Arduino core** управляются compile-time флагом `CORE_DEBUG_LEVEL`.
    Debug-сборки задают уровень 4 и направляют вывод в `Serial` через
    `DEBUG_ESP_PORT`. Логи precompiled ESP-IDF библиотек остаются ограничены

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -215,6 +215,12 @@ These lines are printed directly to Serial and are intended for acceptance
 testing. They cover critical storage, sensor payload, Wi-Fi recovery, display,
 configuration, and OTA failures without requiring a `_debug` build.
 
+Release/tester logs should stay small and machine-readable. Keep raw JSON
+snapshots, full HTTP response bodies, signing internals, sensor internals, and
+memory traces behind verbose/debug logging unless they are promoted to a stable
+tagged contract such as `[PAYLOAD]`, `[DATALOG]`, `[CONNECTIVITY]`,
+`[SUBSYSTEM]`, `[BOOT]`, or `[HEALTH]`.
+
 Some signing/extrinsic lines such as `Signature size: ...` can still be emitted
 directly by `ESPRobonomicsClient`. They are library diagnostics, not part of the
 stable tester contract.
@@ -695,6 +701,12 @@ release-level формате:
 Эти строки печатаются напрямую в Serial и предназначены для приемочного тестера.
 Они покрывают критичные ошибки SD/config, sensor payload, Wi-Fi recovery,
 display и OTA без необходимости собирать `_debug` прошивку.
+
+Release/tester логи должны оставаться короткими и машинно-читаемыми. Сырые JSON
+snapshots, полные HTTP response bodies, детали подписи, sensor internals и memory
+traces нужно держать за verbose/debug логированием, если они не оформлены как
+стабильный tagged-контракт: `[PAYLOAD]`, `[DATALOG]`, `[CONNECTIVITY]`,
+`[SUBSYSTEM]`, `[BOOT]` или `[HEALTH]`.
 
 После загрузки сохраненной конфигурации прошивка сообщает фактически применяемые
 уровни:

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -161,6 +161,7 @@ At boot, firmware reports the effective project and framework levels after the
 saved configuration has been loaded:
 
 ```text
+[BUILD] version=R-INS_2026-06.1-testing+abcdef0 channel=testing commit=abcdef0 model=insight target=esp32c6 language=en profile=release
 [LOG] runtime=4 configured=1 forced=4 core=4
 ```
 
@@ -171,18 +172,23 @@ Sensor upload payloads emit a shared machine-readable snapshot before they are
 signed and sent:
 
 ```text
-[PAYLOAD] channel=datalog data=h:65.15,t:25.84,p:99860.91,nm:75,na:75
-[PAYLOAD] channel=connectivity data=h:65.15,t:25.84,p:99860.91,nm:75,na:75
+[PAYLOAD] channel=datalog encoding=plain encrypted=0 payload_len=49 sample_available=1 sample=h:65.15,t:25.84,p:99860.91
+[PAYLOAD] channel=datalog encoding=cps encrypted=1 payload_len=324 sample_available=0
+[PAYLOAD] channel=sensors-connectivity encoding=mixed encrypted=1 payload_len=280 sample_available=0
 ```
 
-The payload line is useful for tester-side sensor value parsing. It does not
-mean that a network upload has succeeded.
+`payload_len` describes the transport payload. `sample`, when present, is the
+local plaintext measurement snapshot and is not necessarily identical to the
+transport bytes. Release builds expose `sample` only for plain payloads. Debug
+builds may expose `sample` for encrypted payloads too. The payload line does not
+mean that a network or on-chain upload has succeeded.
 
 On-chain Robonomics datalog sends emit stable machine-readable UART events:
 
 ```text
-[DATALOG] attempt payload_len=68 payload_empty=0 owner_self_fallback=0
+[DATALOG] attempt payload_len=68 encoding=plain owner_self_fallback=0
 [DATALOG] success response_len=66
+[DATALOG] failed reason=encryption_failed
 [DATALOG] failed reason=rpc_error code=1010 message=invalid_transaction response_len=111
 ```
 
@@ -199,8 +205,8 @@ Sensors Connectivity uploads emit their own stable machine-readable UART events:
 ```
 
 The `[CONNECTIVITY]` lines describe the HTTP upload attempt and final result.
-Legacy `[Map#...]` lines are verbose diagnostics for host selection and HTTP
-details, not the primary parser contract for automated tests.
+`[Map#...]` lines are verbose diagnostics for host selection and HTTP details,
+not part of the automated tester contract.
 
 Important subsystem failures and recovery events emit stable release-level
 lines:
@@ -712,11 +718,25 @@ traces нужно держать за verbose/debug логированием, е
 уровни:
 
 ```text
+[BUILD] version=R-INS_2026-06.1-testing+abcdef0 channel=testing commit=abcdef0 model=insight target=esp32c6 language=ru profile=release
 [LOG] runtime=4 configured=1 forced=4 core=4
 ```
 
 `configured` — сохраненный `cfg::debug`, `forced` — compile-time минимум, а
 `runtime` — эффективный уровень логов проекта.
+
+Payload выводится в структурированном формате:
+
+```text
+[PAYLOAD] channel=datalog encoding=plain encrypted=0 payload_len=49 sample_available=1 sample=h:65.15,t:25.84,p:99860.91
+[PAYLOAD] channel=datalog encoding=cps encrypted=1 payload_len=324 sample_available=0
+[PAYLOAD] channel=sensors-connectivity encoding=mixed encrypted=1 payload_len=280 sample_available=0
+```
+
+`payload_len` относится к отправляемому payload. Поле `sample` содержит локальный
+plaintext-снимок измерений. Release-сборки выводят `sample` только для plain
+payload. Debug-сборки могут выводить `sample` и для encrypted payload. Наличие
+`[PAYLOAD]` не подтверждает успешную сетевую или on-chain отправку.
 
 Для просмотра логов в реальном времени:
 

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -166,6 +166,18 @@ saved configuration has been loaded:
 Here `configured` is the persisted `cfg::debug`, `forced` is the compile-time
 minimum, and `runtime` is the effective project log level.
 
+On-chain Robonomics datalog sends emit stable machine-readable UART events:
+
+```text
+[DATALOG] attempt payload_len=68 payload_empty=0 owner_self_fallback=0
+[DATALOG] success response_len=66
+[DATALOG] failed reason=rpc_error code=1010 message=invalid_transaction response_len=111
+```
+
+`Datalog data: ...` remains the payload/sensor snapshot used by diagnostics.
+The `[DATALOG]` lines describe the actual on-chain send attempt and final
+result. Timestamp/signature internals are verbose-only diagnostics.
+
 To view these logs live:
 
 1. Connect the board over USB.

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -202,6 +202,19 @@ The `[CONNECTIVITY]` lines describe the HTTP upload attempt and final result.
 Legacy `[Map#...]` lines are verbose diagnostics for host selection and HTTP
 details, not the primary parser contract for automated tests.
 
+Important subsystem failures and recovery events emit stable release-level
+lines:
+
+```text
+[SUBSYSTEM] error subsystem=sd reason=open_append_failed path=/data/SDS011/2026-07-24.csv
+[SUBSYSTEM] error subsystem=ota reason=http_get_failed host=firmware.example code=404
+[SUBSYSTEM] event subsystem=wifi reason=sta_recovery mode=deep status=6 ip=0.0.0.0
+```
+
+These lines are printed directly to Serial and are intended for acceptance
+testing. They cover critical storage, sensor payload, Wi-Fi recovery, display,
+configuration, and OTA failures without requiring a `_debug` build.
+
 Some signing/extrinsic lines such as `Signature size: ...` can still be emitted
 directly by `ESPRobonomicsClient`. They are library diagnostics, not part of the
 stable tester contract.
@@ -663,11 +676,25 @@ pio run -e esp32c3_urban_ru_debug -t upload
 состояния в UART:
 
 ```text
-[HEALTH] uptime=3600 boot=4 heap=219584 rssi=-62 tx=12 errors=0 wifi=1 wifi_errors=0 sensor_errors=0 sd_errors=0
+[HEALTH] uptime=3600 boot=4 heap=219584 rssi=-62 tx=12 errors=0 wifi=1 wifi_errors=0 sensor_errors=0 sd_errors=0 reset_reason=power_on_reset reset_code=1 crash_valid=0 prev_uptime=0 prev_heap=0 last_section_id=0 last_section=Idle/MainLoop
 ```
 
 Начальные поля сохраняются стабильными для простых парсеров. Поля в конце
-добавляют состояние Wi-Fi и отдельные счетчики ошибок по подсистемам.
+добавляют состояние Wi-Fi, отдельные счетчики ошибок по подсистемам и контекст
+перезагрузки.
+
+Важные ошибки подсистем и события восстановления выводятся в стабильном
+release-level формате:
+
+```text
+[SUBSYSTEM] error subsystem=sd reason=open_append_failed path=/data/SDS011/2026-07-24.csv
+[SUBSYSTEM] error subsystem=ota reason=http_get_failed host=firmware.example code=404
+[SUBSYSTEM] event subsystem=wifi reason=sta_recovery mode=deep status=6 ip=0.0.0.0
+```
+
+Эти строки печатаются напрямую в Serial и предназначены для приемочного тестера.
+Они покрывают критичные ошибки SD/config, sensor payload, Wi-Fi recovery,
+display и OTA без необходимости собирать `_debug` прошивку.
 
 После загрузки сохраненной конфигурации прошивка сообщает фактически применяемые
 уровни:

--- a/OTA_Update.cpp
+++ b/OTA_Update.cpp
@@ -5,6 +5,7 @@
 #include <HTTPClient.h>
 #include "defines.h"
 #include "config_manager/config_helpers.h"
+#include "utils.h"
 #include <MD5Builder.h>
 #include <Update.h>
 
@@ -95,11 +96,13 @@ bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status
 
         if (millis() - totalStartTime > OTA_TOTAL_TIMEOUT_MS) {
             debug_outln_error(F("OTA total timeout exceeded"));
+            logSubsystemError(F("ota"), F("total_timeout"));
             return false;
         }
 
         if (WiFi.status() != WL_CONNECTED) {
             debug_outln_error(F("WiFi not connected, aborting OTA"));
+            logSubsystemError(F("ota"), F("wifi_not_connected"));
             return false;
         }
 
@@ -113,12 +116,14 @@ bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status
 
         if (!http.begin(client, host, FW_DOWNLOAD_PORT, url)) {
             debug_outln_error(F("HTTP begin failed"));
+            logSubsystemError(F("ota"), F("http_begin_failed"), String(F("host=")) + host + F(" path=") + url);
             continue;
         }
 
         int httpCode = http.GET();
         if (httpCode != HTTP_CODE_OK) {
             debug_outln_info(F("HTTP GET failed, code: "), String(httpCode));
+            logSubsystemError(F("ota"), F("http_get_failed"), String(F("host=")) + host + F(" code=") + String(httpCode));
             http.end();
             continue;
         }
@@ -126,6 +131,7 @@ bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status
         int contentLength = http.getSize();
         if (contentLength <= 0) {
             debug_outln_error(F("Invalid content length"));
+            logSubsystemError(F("ota"), F("invalid_content_length"), String(F("host=")) + host);
             http.end();
             continue;
         }
@@ -134,6 +140,7 @@ bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status
 
         if (!Update.begin(contentLength)) {
             debug_outln_error(F("Not enough space for OTA"));
+            logSubsystemError(F("ota"), F("not_enough_space"), String(F("size=")) + String(contentLength));
             http.end();
             return false;
         }
@@ -153,6 +160,7 @@ bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status
 
             if (millis() - totalStartTime > OTA_TOTAL_TIMEOUT_MS) {
                 debug_outln_error(F("OTA total timeout exceeded during download"));
+                logSubsystemError(F("ota"), F("download_total_timeout"), String(F("written=")) + String(written));
                 Update.abort();
                 http.end();
                 return false;
@@ -160,6 +168,7 @@ bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status
 
             if (WiFi.status() != WL_CONNECTED) {
                 debug_outln_error(F("WiFi disconnected during OTA"));
+                logSubsystemError(F("ota"), F("wifi_disconnected"), String(F("written=")) + String(written));
                 Update.abort();
                 http.end();
                 return false;
@@ -176,6 +185,7 @@ bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status
 
                     if (Update.write(buffer, bytesRead) != (size_t)bytesRead) {
                         debug_outln_error(F("Update.write failed"));
+                        logSubsystemError(F("ota"), F("write_failed"), String(F("written=")) + String(written));
                         Update.abort();
                         http.end();
                         return false;
@@ -195,6 +205,7 @@ bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status
             } else {
                 if (millis() - lastDataTime > FW_HOST_TIMEOUT_MS) {
                     debug_outln_error(F("OTA stalled, switching host..."));
+                    logSubsystemError(F("ota"), F("stalled"), String(F("host=")) + host + F(" written=") + String(written));
                     download_ok = false;
                     break;
                 }
@@ -214,6 +225,7 @@ bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status
 
         if (!Update.end()) {
             debug_outln_error(F("Update.end failed"));
+            logSubsystemError(F("ota"), F("update_end_failed"));
             Update.abort();
             http.end();
             continue;
@@ -221,6 +233,7 @@ bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status
 
         if (!Update.isFinished()) {
             debug_outln_error(F("Update not finished properly"));
+            logSubsystemError(F("ota"), F("not_finished"));
             http.end();
             continue;
         }
@@ -228,6 +241,7 @@ bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status
         String md5String = Update.md5String();
         if (!md5String.equalsIgnoreCase(expectedMD5)) {
             debug_outln_error(F("MD5 mismatch!"));
+            logSubsystemError(F("ota"), F("md5_mismatch"));
             debug_outln_info(F("Expected: "), expectedMD5);
             debug_outln_info(F("Actual: "), md5String);
             http.end();
@@ -240,6 +254,7 @@ bool downloadAndUpdate(const char* url, const String& expectedMD5, device_status
     }
 
     debug_outln_error(F("OTA failed after all attempts"));
+    logSubsystemError(F("ota"), F("all_attempts_failed"));
     return false;
 }
 
@@ -264,6 +279,7 @@ void twoStageOTAUpdate(device_status_t &deviceStatus, bool manual) {
 	StreamString newFwmd5;
 	if (!fwDownloadStream(client, fetch_md5_name, &newFwmd5, deviceStatus)){
 		debug_outln_info(F("download md5 fail"));
+		logSubsystemError(F("ota"), F("md5_download_failed"), String(F("path=")) + fetch_md5_name);
 		return;}
 	debug_outln_info(F("download md5 end"));
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ Stable unless `ALTRUIST_CHANNEL_TESTING=1` is set explicitly. The build output
 prints the resolved branch, channel, profile, telemetry state, and commit before
 compilation.
 
+Testing release builds also force the project log floor to info level
+(`ALTRUIST_FORCE_LOG_LEVEL=3`). This keeps tester-oriented release logs visible
+even if the device has an older saved `cfg::debug` value, without enabling
+verbose Debug-only diagnostics.
+
 CI sets `ALTRUIST_CHANNEL_TESTING`, `ALTRUIST_HEALTH_TELEMETRY`, and
 `ALTRUIST_BUILD_COMMIT` explicitly, so published builds do not depend on local
 Git state. These variables can also override the automatic local defaults.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ channel controls firmware identity, artifact names, and OTA policy; the build
 profile controls diagnostic verbosity. Debug builds force verbose project logs
 with `ALTRUIST_FORCE_LOG_LEVEL=4`.
 
+The tester UART contract is independent from runtime project logs: `[BOOT]`,
+`[BUILD]`, `[LOG]`, `[HEALTH]`, `[PAYLOAD]`, `[DATALOG]`, `[CONNECTIVITY]`, and
+`[SUBSYSTEM]` are emitted directly to Serial in release builds, while full
+transport payloads, sensor internals, and HTTP details stay behind verbose/debug
+logging.
+
 CI sets `ALTRUIST_CHANNEL_TESTING`, `ALTRUIST_HEALTH_TELEMETRY`, and
 `ALTRUIST_BUILD_COMMIT` explicitly, so published builds do not depend on local
 Git state. These variables can also override the automatic local defaults.

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ Stable unless `ALTRUIST_CHANNEL_TESTING=1` is set explicitly. The build output
 prints the resolved branch, channel, profile, telemetry state, and commit before
 compilation.
 
-Testing release builds also force the project log floor to info level
-(`ALTRUIST_FORCE_LOG_LEVEL=3`). This keeps tester-oriented release logs visible
-even if the device has an older saved `cfg::debug` value, without enabling
-verbose Debug-only diagnostics.
+Stable and Testing release builds use the same runtime logging behavior. The
+channel controls firmware identity, artifact names, and OTA policy; the build
+profile controls diagnostic verbosity. Debug builds force verbose project logs
+with `ALTRUIST_FORCE_LOG_LEVEL=4`.
 
 CI sets `ALTRUIST_CHANNEL_TESTING`, `ALTRUIST_HEALTH_TELEMETRY`, and
 `ALTRUIST_BUILD_COMMIT` explicitly, so published builds do not depend on local

--- a/airrohr-firmware.ino
+++ b/airrohr-firmware.ino
@@ -785,6 +785,13 @@ bool fetchSensors() {
 						debug_outln_info(F("[Sensors] sensor: "), String(activeSensors[i]->sensor_name));
 						debug_outln_info(F("[Sensors] memory/capacity: "),
 						                 String(sensors_data.memoryUsage()) + "/" + String(sensors_data.capacity()));
+						logSubsystemError(
+							F("sensor"),
+							F("json_overflow"),
+							String(F("sensor=")) + activeSensors[i]->sensor_name +
+								F(" memory=") + String(sensors_data.memoryUsage()) +
+								F(" capacity=") + String(sensors_data.capacity())
+						);
 					}
 					xSemaphoreGive(mutex);
 				}
@@ -869,6 +876,7 @@ void sensorAndAPIWorker(void *pvParameters) {
 					    msSince(sta_down_since_ms) >= WIFI_STA_REBOOT_AFTER_MS) {
 						debug_outln_info(F("[WiFi] STA link down too long; rebooting for recovery"));
 						set_restart_reason(RESTART_REASON_WIFI);
+						logSubsystemEvent(F("event"), F("wifi"), F("sta_recovery_reboot"), String(F("down_ms=")) + String(msSince(sta_down_since_ms)));
 						delay(100);
 						esp_restart();
 					}
@@ -942,6 +950,12 @@ void sensorAndAPIWorker(void *pvParameters) {
 					debug_outln_error(F("[API] JSON snapshot overflow; skipping send"));
 					debug_outln_info(F("[API] memory/capacity: "),
 					                 String(api_snapshot.memoryUsage()) + "/" + String(api_snapshot.capacity()));
+					logSubsystemError(
+						F("api"),
+						F("json_snapshot_overflow"),
+						String(F("memory=")) + String(api_snapshot.memoryUsage()) +
+							F(" capacity=") + String(api_snapshot.capacity())
+					);
 				}
 				xSemaphoreGive(mutex);
 			}

--- a/airrohr-firmware.ino
+++ b/airrohr-firmware.ino
@@ -58,6 +58,7 @@
  ************************************************************************/
 #include <WString.h>
 #include <pgmspace.h>
+#include <string.h>
 
 /*****************************************************************
  * Includes                                                      *
@@ -208,6 +209,13 @@ const char* getCrashSectionName(uint8_t section) {
 	}
 }
 
+static void clearCrashContext() {
+	Preferences prefs;
+	prefs.begin("crash", false);
+	prefs.putBool("valid", false);
+	prefs.end();
+}
+
 void saveCrashContext() {
 	Preferences prefs;
 	prefs.begin("crash", false);
@@ -218,7 +226,7 @@ void saveCrashContext() {
 	prefs.end();
 }
 
-CrashContextData loadCrashContext() {
+static CrashContextData readCrashContext(bool clear_after_read) {
 	CrashContextData ctx;
 	ctx.valid = false;
 	ctx.section = 0;
@@ -235,12 +243,98 @@ CrashContextData loadCrashContext() {
 	}
 	prefs.end();
 	
-	Preferences prefs2;
-	prefs2.begin("crash", false);
-	prefs2.putBool("valid", false);
-	prefs2.end();
+	if (clear_after_read) {
+		clearCrashContext();
+	}
 	
 	return ctx;
+}
+
+CrashContextData loadCrashContext() {
+	return readCrashContext(true);
+}
+
+static CrashContextData peekCrashContext() {
+	return readCrashContext(false);
+}
+
+static String machineToken(const char* text) {
+	String token;
+	token.reserve(strlen(text));
+	bool last_separator = false;
+	for (const char* p = text; *p; ++p) {
+		char c = *p;
+		if (c >= 'A' && c <= 'Z') {
+			c = c - 'A' + 'a';
+		}
+		if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+			token += c;
+			last_separator = false;
+		} else if (!last_separator && token.length() > 0) {
+			token += '_';
+			last_separator = true;
+		}
+	}
+	if (token.endsWith("_")) {
+		token.remove(token.length() - 1);
+	}
+	return token.length() > 0 ? token : String(F("unknown"));
+}
+
+static void copyMetricText(char* destination, size_t destination_size, const String& source) {
+	if (destination_size == 0) {
+		return;
+	}
+	source.toCharArray(destination, destination_size);
+	destination[destination_size - 1] = '\0';
+}
+
+static void copyMetricText(char* destination, size_t destination_size, const char* source) {
+	if (destination_size == 0) {
+		return;
+	}
+	strncpy(destination, source, destination_size - 1);
+	destination[destination_size - 1] = '\0';
+}
+
+static void logBootStatus() {
+	const esp_reset_reason_t reason = esp_reset_reason();
+	const CrashContextData ctx = peekCrashContext();
+	const String reset_reason_token = machineToken(get_reset_reason_text());
+	const uint8_t last_section = ctx.valid ? ctx.section : CRASH_SECTION_IDLE;
+	const char* last_section_name = getCrashSectionName(last_section);
+	const uint32_t prev_uptime = ctx.valid ? ctx.uptime_sec : 0;
+	const uint32_t prev_heap = ctx.valid ? ctx.free_heap : 0;
+
+	system_metrics.reset_reason_code = static_cast<int>(reason);
+	copyMetricText(system_metrics.reset_reason, sizeof(system_metrics.reset_reason), reset_reason_token);
+	system_metrics.crash_context_valid = ctx.valid;
+	system_metrics.prev_uptime_sec = prev_uptime;
+	system_metrics.prev_free_heap = prev_heap;
+	system_metrics.last_section_id = last_section;
+	copyMetricText(system_metrics.last_section, sizeof(system_metrics.last_section), last_section_name);
+
+	Serial.print(F("[BOOT] reset_reason="));
+	Serial.print(system_metrics.reset_reason);
+	Serial.print(F(" reset_code="));
+	Serial.print(system_metrics.reset_reason_code);
+	Serial.print(F(" boot="));
+	Serial.print(system_metrics.boot_counter);
+	Serial.print(F(" crash_valid="));
+	Serial.print(system_metrics.crash_context_valid ? 1 : 0);
+	Serial.print(F(" prev_uptime="));
+	Serial.print(system_metrics.prev_uptime_sec);
+	Serial.print(F(" prev_heap="));
+	Serial.print(system_metrics.prev_free_heap);
+	Serial.print(F(" last_section_id="));
+	Serial.print(system_metrics.last_section_id);
+	Serial.print(F(" last_section="));
+	Serial.print(system_metrics.last_section);
+	Serial.print(F(" heap="));
+	Serial.println(ESP.getFreeHeap());
+#if !defined(USE_SD_CARD) || !defined(ALTRUIST_INSIGHT)
+	clearCrashContext();
+#endif
 }
 
 void markMainLoopAlive() {
@@ -1253,6 +1347,7 @@ void setup(void) {
 	Serial.flush();
 	delay(10);
 	initMetrics();
+	logBootStatus();
 	#if defined(ALTRUIST_BUILD_DEBUG)
 	#if defined(ALTRUIST_INSIGHT)
 	Serial.print(F("[INSIGHT][Setup] Metrics initialized. Boot counter: "));

--- a/apis/custom_http_api.cpp
+++ b/apis/custom_http_api.cpp
@@ -25,7 +25,7 @@ void CustomHTTPAPI::_send(JsonDocument &data) {
 		return;
 	}
 	formatDataToSend(data_to_send, data);
-    debug_outln_info(F("custom api data: "), data_to_send);
+    debug_outln_verbose(F("custom api data: "), data_to_send);
 	is_ok = false;
     is_ok = POSTRequest(data_to_send);
 }
@@ -75,10 +75,10 @@ bool CustomHTTPAPI::POSTRequest(const String& data) {
 			return true;
 		} else if (result >= HTTP_CODE_BAD_REQUEST) {
 			debug_outln_info(F("Request failed with error: "), String(result));
-			debug_outln_info(F("Details:"), _http.getString());
+			debug_outln_verbose(F("Details:"), _http.getString());
 		} else {
 			debug_outln_info(F("Request failed with error: "), String(result));
-			debug_outln_info(F("Details:"), HTTPClient::errorToString(result));
+			debug_outln_verbose(F("Details:"), HTTPClient::errorToString(result));
 		}
         _http.end();
     } else {

--- a/apis/custom_http_api.cpp
+++ b/apis/custom_http_api.cpp
@@ -35,7 +35,7 @@ void CustomHTTPAPI::formatDataToSend(String &data_to_send, JsonDocument &data) {
 	double last_value_GPS_lon;
 	String datalog_data;
 	sscanf(cfg::coords_gps, "%lf,%lf", &last_value_GPS_lat, &last_value_GPS_lon);
-	formatRobonomicsString(data, datalog_data);
+	formatRobonomicsString(data, datalog_data, F("custom-http"));
     String signature;
 	addTimeAndSign(datalog_data, signature, robonomics);
     data_to_send = F("{\"robonomics_address\": \"");

--- a/apis/custom_http_api.cpp
+++ b/apis/custom_http_api.cpp
@@ -24,18 +24,25 @@ void CustomHTTPAPI::_send(JsonDocument &data) {
 		is_ok = false;
 		return;
 	}
-	formatDataToSend(data_to_send, data);
+	if (!formatDataToSend(data_to_send, data)) {
+		debug_outln_error(F("[Custom API] Payload encryption failed; send aborted"));
+		is_ok = false;
+		return;
+	}
     debug_outln_verbose(F("custom api data: "), data_to_send);
 	is_ok = false;
     is_ok = POSTRequest(data_to_send);
 }
 
-void CustomHTTPAPI::formatDataToSend(String &data_to_send, JsonDocument &data) {
+bool CustomHTTPAPI::formatDataToSend(String &data_to_send, JsonDocument &data) {
 	double last_value_GPS_lat;
 	double last_value_GPS_lon;
 	String datalog_data;
 	sscanf(cfg::coords_gps, "%lf,%lf", &last_value_GPS_lat, &last_value_GPS_lon);
-	formatRobonomicsString(data, datalog_data, F("custom-http"));
+	if (!formatRobonomicsString(data, datalog_data, F("custom-http"))) {
+		data_to_send = "";
+		return false;
+	}
     String signature;
 	addTimeAndSign(datalog_data, signature, robonomics);
     data_to_send = F("{\"robonomics_address\": \"");
@@ -51,6 +58,7 @@ void CustomHTTPAPI::formatDataToSend(String &data_to_send, JsonDocument &data) {
     data_to_send += "\", \"sensordatavalues\": \"";
     data_to_send += datalog_data;
     data_to_send += "\"}";
+	return true;
 }
 
 bool CustomHTTPAPI::POSTRequest(const String& data) {

--- a/apis/custom_http_api.h
+++ b/apis/custom_http_api.h
@@ -26,7 +26,7 @@ private:
     Robonomics* robonomics;
     void _send(JsonDocument &data) override;
     bool POSTRequest(const String& data);
-    void formatDataToSend(String &data_to_send, JsonDocument &data);
+    bool formatDataToSend(String &data_to_send, JsonDocument &data);
 };
 
 #endif  // __CUSTOM_API_H__

--- a/apis/helpers/message_formatter.cpp
+++ b/apis/helpers/message_formatter.cpp
@@ -152,9 +152,9 @@ static void appendRobonomicsFields(JsonDocument &data, String &out, bool per_fie
 	}
 }
 
-void formatRobonomicsString(JsonDocument &data, String &datalog_data) {
+void formatRobonomicsString(JsonDocument &data, String &datalog_data, const __FlashStringHelper *channel) {
 	appendRobonomicsFields(data, datalog_data, true);
-	debug_outln_info(F("Map sensor data: "), datalog_data);
+	debug_outln_info(String(F("[PAYLOAD] channel=")) + String(channel) + F(" data=") + datalog_data);
 }
 
 DatalogFormatStatus formatRobonomicsDatalogString(JsonDocument &data, String &datalog_data) {

--- a/apis/helpers/message_formatter.cpp
+++ b/apis/helpers/message_formatter.cpp
@@ -68,11 +68,27 @@ static bool signMessageRaw(const String &message, String &signature, Robonomics 
 	return true;
 }
 
-static String maybeEncryptValue(const String &value, bool should_encrypt) {
+static bool maybeEncryptValue(const String &value, bool should_encrypt, String &formatted) {
 	if (!should_encrypt || value.isEmpty()) {
-		return value;
+		formatted = value;
+		return true;
 	}
-	return valueCryptoEncryptValue(value);
+	formatted = valueCryptoEncryptValue(value);
+	return formatted.startsWith(VALUE_CRYPTO_CPS_PREFIX);
+}
+
+static bool appendRobonomicsValue(String &out, const __FlashStringHelper *alias, const String &value,
+				  bool should_encrypt) {
+	String formatted;
+	if (!maybeEncryptValue(value, should_encrypt, formatted)) {
+		out = "";
+		return false;
+	}
+	out += alias;
+	out += ':';
+	out += formatted;
+	out += ',';
+	return true;
 }
 
 /** Robonomics parachain datalog pallet hard limit (see MaximumMessageSize). */
@@ -85,7 +101,7 @@ static bool anyMetricEncryptionEnabled() {
 	       cfg::encrypt_o3 || cfg::encrypt_no2 || cfg::encrypt_fast_aqi || cfg::encrypt_epa_aqi;
 }
 
-static void appendRobonomicsFields(JsonDocument &data, String &out, bool per_field_encrypt) {
+static bool appendRobonomicsFields(JsonDocument &data, String &out, bool per_field_encrypt) {
 	out = "";
 
 	bool has_scd4x = !data[SCD4X_SENSOR_NAME].isNull();
@@ -116,50 +132,58 @@ static void appendRobonomicsFields(JsonDocument &data, String &out, bool per_fie
 			const bool encrypt_climate = cfg::encrypt_temperature || cfg::encrypt_humidity;
 
 			if (type == "P1" && cfg::share_pm) {
-				out += "p1:" + maybeEncryptValue(value, per_field_encrypt && cfg::encrypt_pm) + ",";
+				if (!appendRobonomicsValue(out, F("p1"), value, per_field_encrypt && cfg::encrypt_pm)) return false;
 			} else if (type == "P2" && cfg::share_pm) {
-				out += "p2:" + maybeEncryptValue(value, per_field_encrypt && cfg::encrypt_pm) + ",";
+				if (!appendRobonomicsValue(out, F("p2"), value, per_field_encrypt && cfg::encrypt_pm)) return false;
 			} else if (type == "noiseMax" && cfg::share_noise) {
-				out += "nm:" + maybeEncryptValue(value, per_field_encrypt && cfg::encrypt_noise) + ",";
+				if (!appendRobonomicsValue(out, F("nm"), value, per_field_encrypt && cfg::encrypt_noise)) return false;
 			} else if (type == "noiseAvg" && cfg::share_noise) {
-				out += "na:" + maybeEncryptValue(value, per_field_encrypt && cfg::encrypt_noise) + ",";
+				if (!appendRobonomicsValue(out, F("na"), value, per_field_encrypt && cfg::encrypt_noise)) return false;
 			} else if (type == "temperature" && cfg::share_temperature && out.indexOf("t:") == -1 &&
 				   !skip_temp_hum) {
-				out += "t:" + maybeEncryptValue(value, per_field_encrypt && encrypt_climate) + ",";
+				if (!appendRobonomicsValue(out, F("t"), value, per_field_encrypt && encrypt_climate)) return false;
 			} else if (type == "pressure" && cfg::share_pressure) {
-				out += "p:" + maybeEncryptValue(value, per_field_encrypt && cfg::encrypt_pressure) + ",";
+				if (!appendRobonomicsValue(out, F("p"), value, per_field_encrypt && cfg::encrypt_pressure)) return false;
 			} else if (type == "humidity" && cfg::share_humidity && out.indexOf("h:") == -1 && !skip_temp_hum) {
-				out += "h:" + maybeEncryptValue(value, per_field_encrypt && encrypt_climate) + ",";
+				if (!appendRobonomicsValue(out, F("h"), value, per_field_encrypt && encrypt_climate)) return false;
 			} else if (type == "radiation") {
-				out += "gc:" + maybeEncryptValue(value, per_field_encrypt && cfg::encrypt_radiation) + ",";
+				if (!appendRobonomicsValue(out, F("gc"), value, per_field_encrypt && cfg::encrypt_radiation)) return false;
 			} else if (type == "co2" && cfg::share_co2) {
-				out += "co2:" + maybeEncryptValue(value, per_field_encrypt && cfg::encrypt_co2) + ",";
+				if (!appendRobonomicsValue(out, F("co2"), value, per_field_encrypt && cfg::encrypt_co2)) return false;
 			} else if (type == "co" && cfg::share_co) {
-				out += "co:" + maybeEncryptValue(value, per_field_encrypt && cfg::encrypt_co) + ",";
+				if (!appendRobonomicsValue(out, F("co"), value, per_field_encrypt && cfg::encrypt_co)) return false;
 			} else if (type == "o3" && cfg::share_o3) {
-				out += "o3:" + maybeEncryptValue(value, per_field_encrypt && cfg::encrypt_o3) + ",";
+				if (!appendRobonomicsValue(out, F("o3"), value, per_field_encrypt && cfg::encrypt_o3)) return false;
 			} else if (type == "no2" && cfg::share_no2) {
-				out += "no2:" + maybeEncryptValue(value, per_field_encrypt && cfg::encrypt_no2) + ",";
+				if (!appendRobonomicsValue(out, F("no2"), value, per_field_encrypt && cfg::encrypt_no2)) return false;
 			} else if (type == "fast_aqi" && cfg::share_fast_aqi) {
-				out += "fa:" + maybeEncryptValue(value, per_field_encrypt && cfg::encrypt_fast_aqi) + ",";
+				if (!appendRobonomicsValue(out, F("fa"), value, per_field_encrypt && cfg::encrypt_fast_aqi)) return false;
 			} else if (type == "epa_aqi" && cfg::share_epa_aqi) {
-				out += "ea:" + maybeEncryptValue(value, per_field_encrypt && cfg::encrypt_epa_aqi) + ",";
+				if (!appendRobonomicsValue(out, F("ea"), value, per_field_encrypt && cfg::encrypt_epa_aqi)) return false;
 			}
 		}
 	}
 	if (out.length() > 0) {
 		out.remove(out.length() - 1);
 	}
+	return true;
 }
 
-void formatRobonomicsString(JsonDocument &data, String &datalog_data, const __FlashStringHelper *channel) {
-	appendRobonomicsFields(data, datalog_data, true);
+bool formatRobonomicsString(JsonDocument &data, String &datalog_data, const __FlashStringHelper *channel) {
+	if (!appendRobonomicsFields(data, datalog_data, true)) {
+		debug_outln_error(F("[Payload] Encryption failed; send aborted"));
+		return false;
+	}
 	debug_outln_info(String(F("[PAYLOAD] channel=")) + String(channel) + F(" data=") + datalog_data);
+	return true;
 }
 
 DatalogFormatStatus formatRobonomicsDatalogString(JsonDocument &data, String &datalog_data) {
 	String plain;
-	appendRobonomicsFields(data, plain, false);
+	if (!appendRobonomicsFields(data, plain, false)) {
+		datalog_data = "";
+		return DATALOG_FORMAT_ENCRYPTION_FAILED;
+	}
 	if (plain.isEmpty()) {
 		datalog_data = plain;
 		debug_outln_info(F("[Datalog] Plain record (empty): "), datalog_data);

--- a/apis/helpers/message_formatter.cpp
+++ b/apis/helpers/message_formatter.cpp
@@ -78,11 +78,14 @@ static bool maybeEncryptValue(const String &value, bool should_encrypt, String &
 }
 
 static bool appendRobonomicsValue(String &out, const __FlashStringHelper *alias, const String &value,
-				  bool should_encrypt) {
+				  bool should_encrypt, bool *encrypted_any) {
 	String formatted;
 	if (!maybeEncryptValue(value, should_encrypt, formatted)) {
 		out = "";
 		return false;
+	}
+	if (should_encrypt && !value.isEmpty() && encrypted_any) {
+		*encrypted_any = true;
 	}
 	out += alias;
 	out += ':';
@@ -101,8 +104,12 @@ static bool anyMetricEncryptionEnabled() {
 	       cfg::encrypt_o3 || cfg::encrypt_no2 || cfg::encrypt_fast_aqi || cfg::encrypt_epa_aqi;
 }
 
-static bool appendRobonomicsFields(JsonDocument &data, String &out, bool per_field_encrypt) {
+static bool appendRobonomicsFields(JsonDocument &data, String &out, bool per_field_encrypt,
+				   bool *encrypted_any = nullptr) {
 	out = "";
+	if (encrypted_any) {
+		*encrypted_any = false;
+	}
 
 	bool has_scd4x = !data[SCD4X_SENSOR_NAME].isNull();
 	bool use_bme680_for_temp_hum = !has_scd4x || (millis() / 1000 < SCD4X_WARMUP_SEC);
@@ -132,34 +139,34 @@ static bool appendRobonomicsFields(JsonDocument &data, String &out, bool per_fie
 			const bool encrypt_climate = cfg::encrypt_temperature || cfg::encrypt_humidity;
 
 			if (type == "P1" && cfg::share_pm) {
-				if (!appendRobonomicsValue(out, F("p1"), value, per_field_encrypt && cfg::encrypt_pm)) return false;
+				if (!appendRobonomicsValue(out, F("p1"), value, per_field_encrypt && cfg::encrypt_pm, encrypted_any)) return false;
 			} else if (type == "P2" && cfg::share_pm) {
-				if (!appendRobonomicsValue(out, F("p2"), value, per_field_encrypt && cfg::encrypt_pm)) return false;
+				if (!appendRobonomicsValue(out, F("p2"), value, per_field_encrypt && cfg::encrypt_pm, encrypted_any)) return false;
 			} else if (type == "noiseMax" && cfg::share_noise) {
-				if (!appendRobonomicsValue(out, F("nm"), value, per_field_encrypt && cfg::encrypt_noise)) return false;
+				if (!appendRobonomicsValue(out, F("nm"), value, per_field_encrypt && cfg::encrypt_noise, encrypted_any)) return false;
 			} else if (type == "noiseAvg" && cfg::share_noise) {
-				if (!appendRobonomicsValue(out, F("na"), value, per_field_encrypt && cfg::encrypt_noise)) return false;
+				if (!appendRobonomicsValue(out, F("na"), value, per_field_encrypt && cfg::encrypt_noise, encrypted_any)) return false;
 			} else if (type == "temperature" && cfg::share_temperature && out.indexOf("t:") == -1 &&
 				   !skip_temp_hum) {
-				if (!appendRobonomicsValue(out, F("t"), value, per_field_encrypt && encrypt_climate)) return false;
+				if (!appendRobonomicsValue(out, F("t"), value, per_field_encrypt && encrypt_climate, encrypted_any)) return false;
 			} else if (type == "pressure" && cfg::share_pressure) {
-				if (!appendRobonomicsValue(out, F("p"), value, per_field_encrypt && cfg::encrypt_pressure)) return false;
+				if (!appendRobonomicsValue(out, F("p"), value, per_field_encrypt && cfg::encrypt_pressure, encrypted_any)) return false;
 			} else if (type == "humidity" && cfg::share_humidity && out.indexOf("h:") == -1 && !skip_temp_hum) {
-				if (!appendRobonomicsValue(out, F("h"), value, per_field_encrypt && encrypt_climate)) return false;
+				if (!appendRobonomicsValue(out, F("h"), value, per_field_encrypt && encrypt_climate, encrypted_any)) return false;
 			} else if (type == "radiation") {
-				if (!appendRobonomicsValue(out, F("gc"), value, per_field_encrypt && cfg::encrypt_radiation)) return false;
+				if (!appendRobonomicsValue(out, F("gc"), value, per_field_encrypt && cfg::encrypt_radiation, encrypted_any)) return false;
 			} else if (type == "co2" && cfg::share_co2) {
-				if (!appendRobonomicsValue(out, F("co2"), value, per_field_encrypt && cfg::encrypt_co2)) return false;
+				if (!appendRobonomicsValue(out, F("co2"), value, per_field_encrypt && cfg::encrypt_co2, encrypted_any)) return false;
 			} else if (type == "co" && cfg::share_co) {
-				if (!appendRobonomicsValue(out, F("co"), value, per_field_encrypt && cfg::encrypt_co)) return false;
+				if (!appendRobonomicsValue(out, F("co"), value, per_field_encrypt && cfg::encrypt_co, encrypted_any)) return false;
 			} else if (type == "o3" && cfg::share_o3) {
-				if (!appendRobonomicsValue(out, F("o3"), value, per_field_encrypt && cfg::encrypt_o3)) return false;
+				if (!appendRobonomicsValue(out, F("o3"), value, per_field_encrypt && cfg::encrypt_o3, encrypted_any)) return false;
 			} else if (type == "no2" && cfg::share_no2) {
-				if (!appendRobonomicsValue(out, F("no2"), value, per_field_encrypt && cfg::encrypt_no2)) return false;
+				if (!appendRobonomicsValue(out, F("no2"), value, per_field_encrypt && cfg::encrypt_no2, encrypted_any)) return false;
 			} else if (type == "fast_aqi" && cfg::share_fast_aqi) {
-				if (!appendRobonomicsValue(out, F("fa"), value, per_field_encrypt && cfg::encrypt_fast_aqi)) return false;
+				if (!appendRobonomicsValue(out, F("fa"), value, per_field_encrypt && cfg::encrypt_fast_aqi, encrypted_any)) return false;
 			} else if (type == "epa_aqi" && cfg::share_epa_aqi) {
-				if (!appendRobonomicsValue(out, F("ea"), value, per_field_encrypt && cfg::encrypt_epa_aqi)) return false;
+				if (!appendRobonomicsValue(out, F("ea"), value, per_field_encrypt && cfg::encrypt_epa_aqi, encrypted_any)) return false;
 			}
 		}
 	}
@@ -169,12 +176,63 @@ static bool appendRobonomicsFields(JsonDocument &data, String &out, bool per_fie
 	return true;
 }
 
+static const String *plainSampleForLog(const String &plain, bool encrypted) {
+	if (plain.isEmpty()) {
+		return nullptr;
+	}
+#if defined(ALTRUIST_BUILD_DEBUG)
+	(void)encrypted;
+	return &plain;
+#else
+	return encrypted ? nullptr : &plain;
+#endif
+}
+
+static void logPayload(const __FlashStringHelper *channel, const char *encoding, bool encrypted,
+			       size_t payload_len, const String *sample) {
+	String line;
+	line.reserve(112 + (sample ? sample->length() : 0));
+	line = F("[PAYLOAD] channel=");
+	line += channel;
+	line += F(" encoding=");
+	line += encoding;
+	line += F(" encrypted=");
+	line += encrypted ? '1' : '0';
+	line += F(" payload_len=");
+	line += String(payload_len);
+	line += F(" sample_available=");
+	line += sample ? '1' : '0';
+	if (sample) {
+		line += F(" sample=");
+		line += *sample;
+	}
+	Serial.println(line);
+}
+
 bool formatRobonomicsString(JsonDocument &data, String &datalog_data, const __FlashStringHelper *channel) {
-	if (!appendRobonomicsFields(data, datalog_data, true)) {
+	bool encrypted_any = false;
+	if (!appendRobonomicsFields(data, datalog_data, true, &encrypted_any)) {
 		debug_outln_error(F("[Payload] Encryption failed; send aborted"));
 		return false;
 	}
-	debug_outln_info(String(F("[PAYLOAD] channel=")) + String(channel) + F(" data=") + datalog_data);
+
+	const String *sample = datalog_data.isEmpty() ? nullptr : &datalog_data;
+#if defined(ALTRUIST_BUILD_DEBUG)
+	String plain_sample;
+	if (encrypted_any) {
+		if (!appendRobonomicsFields(data, plain_sample, false)) {
+			return false;
+		}
+		sample = plain_sample.isEmpty() ? nullptr : &plain_sample;
+	}
+#else
+	if (encrypted_any) {
+		sample = nullptr;
+	}
+#endif
+
+	logPayload(channel, encrypted_any ? "mixed" : "plain", encrypted_any, datalog_data.length(), sample);
+	debug_outln_verbose(F("[Payload] Wire data: "), datalog_data);
 	return true;
 }
 
@@ -186,12 +244,14 @@ DatalogFormatStatus formatRobonomicsDatalogString(JsonDocument &data, String &da
 	}
 	if (plain.isEmpty()) {
 		datalog_data = plain;
-		debug_outln_info(F("[Datalog] Plain record (empty): "), datalog_data);
+		logPayload(F("datalog"), "plain", false, 0, nullptr);
+		debug_outln_verbose(F("[Datalog] Plain record (empty): "), datalog_data);
 		return DATALOG_FORMAT_PAYLOAD_EMPTY;
 	}
 
 	if (!anyMetricEncryptionEnabled()) {
 		if (plain.length() > DATALOG_CHAIN_SAFE_BYTES) {
+			logPayload(F("datalog"), "plain", false, plain.length(), plainSampleForLog(plain, false));
 			debug_outln_error(F("[Datalog] Plain record too large for chain limit"));
 			debug_outln_verbose(String(F("[Datalog] Record size: ")) + String(plain.length()) + F(" bytes (max ") +
 					    String(DATALOG_CHAIN_MAX_BYTES) + F(")"));
@@ -199,7 +259,8 @@ DatalogFormatStatus formatRobonomicsDatalogString(JsonDocument &data, String &da
 			return DATALOG_FORMAT_PAYLOAD_TOO_LARGE;
 		}
 		datalog_data = plain;
-		debug_outln_info(F("[Datalog] Plain record: "), datalog_data);
+		logPayload(F("datalog"), "plain", false, datalog_data.length(), plainSampleForLog(plain, false));
+		debug_outln_verbose(F("[Datalog] Plain record: "), datalog_data);
 		return DATALOG_FORMAT_PLAIN;
 	}
 
@@ -207,18 +268,21 @@ DatalogFormatStatus formatRobonomicsDatalogString(JsonDocument &data, String &da
 	if (encrypted.startsWith(VALUE_CRYPTO_CPS_PREFIX) &&
 	    encrypted.length() <= DATALOG_CHAIN_SAFE_BYTES) {
 		datalog_data = encrypted;
-		debug_outln_info(String(F("[Datalog] Bulk encrypted record (")) + String(datalog_data.length()) +
-					 F(" bytes): ") + datalog_data);
+		logPayload(F("datalog"), "cps", true, datalog_data.length(), plainSampleForLog(plain, true));
+		debug_outln_verbose(String(F("[Datalog] Bulk encrypted record (")) + String(datalog_data.length()) +
+					    F(" bytes): ") + datalog_data);
 		return DATALOG_FORMAT_CPS;
 	}
 
 	if (encrypted.startsWith(VALUE_CRYPTO_CPS_PREFIX) && encrypted.length() > DATALOG_CHAIN_SAFE_BYTES) {
+		logPayload(F("datalog"), "cps", true, encrypted.length(), plainSampleForLog(plain, true));
 		debug_outln_error(F("[Datalog] Bulk encrypted record too large for chain limit"));
 		debug_outln_verbose(String(F("[Datalog] Record size: ")) + String(encrypted.length()) + F(" bytes (max ") +
 				    String(DATALOG_CHAIN_MAX_BYTES) + F(")"));
 		datalog_data = "";
 		return DATALOG_FORMAT_PAYLOAD_TOO_LARGE;
 	} else {
+		logPayload(F("datalog"), "cps", true, 0, plainSampleForLog(plain, true));
 		debug_outln_error(F("[Datalog] Bulk encrypt failed; not sending plaintext fallback"));
 	}
 	datalog_data = "";

--- a/apis/helpers/message_formatter.cpp
+++ b/apis/helpers/message_formatter.cpp
@@ -157,19 +157,26 @@ void formatRobonomicsString(JsonDocument &data, String &datalog_data) {
 	debug_outln_info(F("Map sensor data: "), datalog_data);
 }
 
-void formatRobonomicsDatalogString(JsonDocument &data, String &datalog_data) {
+DatalogFormatStatus formatRobonomicsDatalogString(JsonDocument &data, String &datalog_data) {
 	String plain;
 	appendRobonomicsFields(data, plain, false);
 	if (plain.isEmpty()) {
 		datalog_data = plain;
 		debug_outln_info(F("[Datalog] Plain record (empty): "), datalog_data);
-		return;
+		return DATALOG_FORMAT_PAYLOAD_EMPTY;
 	}
 
 	if (!anyMetricEncryptionEnabled()) {
+		if (plain.length() > DATALOG_CHAIN_SAFE_BYTES) {
+			debug_outln_error(F("[Datalog] Plain record too large for chain limit"));
+			debug_outln_verbose(String(F("[Datalog] Record size: ")) + String(plain.length()) + F(" bytes (max ") +
+					    String(DATALOG_CHAIN_MAX_BYTES) + F(")"));
+			datalog_data = "";
+			return DATALOG_FORMAT_PAYLOAD_TOO_LARGE;
+		}
 		datalog_data = plain;
 		debug_outln_info(F("[Datalog] Plain record: "), datalog_data);
-		return;
+		return DATALOG_FORMAT_PLAIN;
 	}
 
 	const String encrypted = valueCryptoEncryptValue(plain);
@@ -178,17 +185,20 @@ void formatRobonomicsDatalogString(JsonDocument &data, String &datalog_data) {
 		datalog_data = encrypted;
 		debug_outln_info(String(F("[Datalog] Bulk encrypted record (")) + String(datalog_data.length()) +
 					 F(" bytes): ") + datalog_data);
-		return;
+		return DATALOG_FORMAT_CPS;
 	}
 
 	if (encrypted.startsWith(VALUE_CRYPTO_CPS_PREFIX) && encrypted.length() > DATALOG_CHAIN_SAFE_BYTES) {
 		debug_outln_error(F("[Datalog] Bulk encrypted record too large for chain limit"));
 		debug_outln_verbose(String(F("[Datalog] Record size: ")) + String(encrypted.length()) + F(" bytes (max ") +
 				    String(DATALOG_CHAIN_MAX_BYTES) + F(")"));
+		datalog_data = "";
+		return DATALOG_FORMAT_PAYLOAD_TOO_LARGE;
 	} else {
 		debug_outln_error(F("[Datalog] Bulk encrypt failed; not sending plaintext fallback"));
 	}
 	datalog_data = "";
+	return DATALOG_FORMAT_ENCRYPTION_FAILED;
 }
 
 void addTimeAndSign(const String &data, String &signature, Robonomics *robonomics) {
@@ -198,7 +208,7 @@ void addTimeAndSign(const String &data, String &signature, Robonomics *robonomic
     debug_outln_verbose(F("Failed to obtain time"));
     return;
   }
-  debug_outln_info(F("Local time: "), timeinfo.tm_hour);
+  debug_outln_verbose(F("Local time: "), String(timeinfo.tm_hour));
   
   // Convert local time to a Unix timestamp.
   time_t timestamp = mktime(&timeinfo);
@@ -209,12 +219,11 @@ void addTimeAndSign(const String &data, String &signature, Robonomics *robonomic
     timestampStr = timestampStr.substring(0, timestampStr.length() - 2);
   }
   
-  debug_outln_info(F("Modified Timestamp: "), timestampStr);
+  debug_outln_verbose(F("Modified Timestamp: "), timestampStr);
 
   String messageWithTimestamp = data + ",time:" + timestampStr;
 
-  debug_outln_info(F("Message to sign: "), messageWithTimestamp);
-  debug_outln_info(F("Message length: "), String(messageWithTimestamp.length()));
+  debug_outln_verbose(F("Message to sign: "), messageWithTimestamp);
 
   if (!signMessageRaw(messageWithTimestamp, signature, robonomics)) {
     signature = "";
@@ -222,5 +231,5 @@ void addTimeAndSign(const String &data, String &signature, Robonomics *robonomic
     return;
   }
 
-  debug_outln_info(F("Signature: "), signature);
+  debug_outln_verbose(F("Signature: "), signature);
 }

--- a/apis/helpers/message_formatter.h
+++ b/apis/helpers/message_formatter.h
@@ -5,7 +5,10 @@
 #include <ArduinoJson.h>
 #include <Robonomics.h>
 
-/** Map / connectivity: per-field CPS encrypt where configured. */
+/**
+ * Map / connectivity: per-field CPS encrypt where configured and emit the
+ * stable UART payload metadata. Returns false on encryption failure.
+ */
 bool formatRobonomicsString(
 	JsonDocument &data,
 	String &datalog_data,

--- a/apis/helpers/message_formatter.h
+++ b/apis/helpers/message_formatter.h
@@ -6,7 +6,7 @@
 #include <Robonomics.h>
 
 /** Map / connectivity: per-field CPS encrypt where configured. */
-void formatRobonomicsString(
+bool formatRobonomicsString(
 	JsonDocument &data,
 	String &datalog_data,
 	const __FlashStringHelper *channel = F("connectivity")

--- a/apis/helpers/message_formatter.h
+++ b/apis/helpers/message_formatter.h
@@ -11,7 +11,15 @@ void formatRobonomicsString(JsonDocument &data, String &datalog_data);
  * On-chain datalog: plain CSV, then one CPS blob if any encrypt flag is on
  * (fits Robonomics 512-byte record limit). Map/connectivity unchanged.
  */
-void formatRobonomicsDatalogString(JsonDocument &data, String &datalog_data);
+enum DatalogFormatStatus {
+	DATALOG_FORMAT_PLAIN,
+	DATALOG_FORMAT_CPS,
+	DATALOG_FORMAT_PAYLOAD_EMPTY,
+	DATALOG_FORMAT_ENCRYPTION_FAILED,
+	DATALOG_FORMAT_PAYLOAD_TOO_LARGE,
+};
+
+DatalogFormatStatus formatRobonomicsDatalogString(JsonDocument &data, String &datalog_data);
 
 void addTimeAndSign(const String &data, String &signature, Robonomics *robonomics);
 

--- a/apis/helpers/message_formatter.h
+++ b/apis/helpers/message_formatter.h
@@ -1,11 +1,16 @@
 #ifndef __MSG_FORMATTER_H__
 #define __MSG_FORMATTER_H__
 
+#include <Arduino.h>
 #include <ArduinoJson.h>
 #include <Robonomics.h>
 
 /** Map / connectivity: per-field CPS encrypt where configured. */
-void formatRobonomicsString(JsonDocument &data, String &datalog_data);
+void formatRobonomicsString(
+	JsonDocument &data,
+	String &datalog_data,
+	const __FlashStringHelper *channel = F("connectivity")
+);
 
 /**
  * On-chain datalog: plain CSV, then one CPS blob if any encrypt flag is on

--- a/apis/helpers/value_crypto.cpp
+++ b/apis/helpers/value_crypto.cpp
@@ -606,7 +606,8 @@ String encryptCpsForOwner(const String &plain, const char *sender_sk_hex, const 
 /**
  * Convenience wrapper for the formatter:
  * uses cfg::private_key + cfg::rws_owner to encrypt a value.
- * If keys are missing / on error — returns original plaintext (better plain than a broken packet).
+ * If keys are missing or encryption fails, returns an empty string so callers
+ * can fail closed instead of sending plaintext.
  */
 String encryptValue(const String &plain) {
 	if (plain.isEmpty()) {
@@ -615,14 +616,14 @@ String encryptValue(const String &plain) {
 	const char *sk = cfg::private_key;
 	if (!sk || strcasecmp(sk, "Not Set") == 0 || strlen(sk) < 64) {
 		debug_outln_error(F("[CPS] Device private key not set; cannot encrypt"));
-		return plain;
+		return String();
 	}
 	const String cps = encryptCpsForOwner(plain, sk, cfg::rws_owner);
 	if (!cps.isEmpty()) {
 		return cps;
 	}
-	debug_outln_error(F("[CPS] Encrypt failed; sending plain value"));
-	return plain;
+	debug_outln_error(F("[CPS] Encrypt failed; plaintext fallback disabled"));
+	return String();
 }
 
 }  // namespace cps

--- a/apis/helpers/value_crypto.h
+++ b/apis/helpers/value_crypto.h
@@ -25,7 +25,8 @@ String valueCryptoEncryptCpsForOwner(const String &plain, const char *sender_sk_
 
 /**
  * Encrypt using device config (private_key + rws_owner).
- * On error, returns the original plain text.
+ * On error, returns an empty string. Callers must abort the send rather than
+ * fall back to plaintext.
  */
 String valueCryptoEncryptValue(const String &plain);
 

--- a/apis/robonomics_datalog_api.cpp
+++ b/apis/robonomics_datalog_api.cpp
@@ -3,48 +3,207 @@
 #include "helpers/message_formatter.h"
 #include "../utils.h"
 
-void RobonomicsDatalogAPI::setup() {
+namespace
+{
+
+    String datalogToken(const String &text)
+    {
+        String token;
+        token.reserve(text.length());
+        bool last_separator = false;
+        for (size_t i = 0; i < text.length(); ++i)
+        {
+            char c = text.charAt(i);
+            if (c >= 'A' && c <= 'Z')
+            {
+                c = c - 'A' + 'a';
+            }
+            if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9'))
+            {
+                token += c;
+                last_separator = false;
+            }
+            else if (!last_separator && token.length() > 0)
+            {
+                token += '_';
+                last_separator = true;
+            }
+        }
+        if (token.endsWith("_"))
+        {
+            token.remove(token.length() - 1);
+        }
+        return token.length() > 0 ? token : String(F("unknown"));
+    }
+
+    const char *datalogEncoding(DatalogFormatStatus status)
+    {
+        return status == DATALOG_FORMAT_CPS ? "cps" : "plain";
+    }
+
+    const char *datalogFormatFailureReason(DatalogFormatStatus status)
+    {
+        switch (status)
+        {
+        case DATALOG_FORMAT_PAYLOAD_EMPTY:
+            return "payload_empty";
+        case DATALOG_FORMAT_ENCRYPTION_FAILED:
+            return "encryption_failed";
+        case DATALOG_FORMAT_PAYLOAD_TOO_LARGE:
+            return "payload_too_large";
+        default:
+            return "formatting_failed";
+        }
+    }
+
+    void logDatalogAttempt(size_t payload_len, const char *encoding, bool using_self_owner)
+    {
+        Serial.print(F("[DATALOG] attempt payload_len="));
+        Serial.print(payload_len);
+        Serial.print(F(" encoding="));
+        Serial.print(encoding);
+        Serial.print(F(" owner_self_fallback="));
+        Serial.println(using_self_owner ? 1 : 0);
+    }
+
+    void logDatalogSuccess(size_t response_len)
+    {
+        Serial.print(F("\r\n[DATALOG] success response_len="));
+        Serial.println(response_len);
+    }
+
+    void logDatalogLocalFailure(const char *reason)
+    {
+        Serial.print(F("[DATALOG] failed reason="));
+        Serial.println(reason);
+    }
+
+    void logDatalogFailure(const String &reason, int code, const String &message, size_t response_len)
+    {
+        Serial.print(F("\r\n[DATALOG] failed reason="));
+        Serial.print(reason);
+        Serial.print(F(" code="));
+        Serial.print(code);
+        Serial.print(F(" message="));
+        Serial.print(message);
+        Serial.print(F(" response_len="));
+        Serial.println(response_len);
+    }
+
+    bool parseRpcError(const String &response, int &code, String &message)
+    {
+        StaticJsonDocument<256> doc;
+        DeserializationError error = deserializeJson(doc, response);
+        if (error)
+        {
+            return false;
+        }
+
+        JsonVariant error_object = doc["error"];
+        JsonVariant code_value;
+        JsonVariant message_value;
+        if (error_object.isNull())
+        {
+            code_value = doc["code"];
+            message_value = doc["message"];
+        }
+        else
+        {
+            code_value = error_object["code"];
+            message_value = error_object["message"];
+        }
+        if (code_value.isNull() && message_value.isNull())
+        {
+            return false;
+        }
+
+        if (code_value.is<int>())
+        {
+            code = code_value.as<int>();
+        }
+        else
+        {
+            code = 0;
+        }
+        if (message_value.is<const char *>())
+        {
+            message = datalogToken(String(message_value.as<const char *>()));
+        }
+        else
+        {
+            message = F("rpc_error");
+        }
+        return true;
+    }
+
+} // namespace
+
+void RobonomicsDatalogAPI::setup()
+{
     api_name = "Robonomics Datalog";
     timeout = getConfigUintValue("datalog_sending_intervall_ms");
     rws_owner = getConfigStringValue("rws_owner");
     private_key = getConfigStringValue("private_key");
     robonomics_public_node = getConfigStringValue("robonomics_public_node");
-    if (strcmp(private_key.c_str(), "Not Set") == 0) {
-		robonomics->generateAndSetPrivateKey();
-		saveRobonomicsPrivateKey(robonomics->getPrivateKey());
-	} else {
-		robonomics->setPrivateKey(private_key.c_str());
-	}
+    if (strcmp(private_key.c_str(), "Not Set") == 0)
+    {
+        robonomics->generateAndSetPrivateKey();
+        saveRobonomicsPrivateKey(robonomics->getPrivateKey());
+    }
+    else
+    {
+        robonomics->setPrivateKey(private_key.c_str());
+    }
     robonomics->setup(robonomics_public_node);
     // CPS vectors: call valueCryptoSelfTest() manually when touching value_crypto.
-    debug_outln_info(F("Robonomics datalog API is ready with sending interval (sec): "), String(timeout/1000));
+    debug_outln_info(F("Robonomics datalog API is ready with sending interval (sec): "), String(timeout / 1000));
 }
 
-void RobonomicsDatalogAPI::_send(JsonDocument &data) {
+void RobonomicsDatalogAPI::_send(JsonDocument &data)
+{
     rws_owner = String(cfg::rws_owner);
     rws_owner.trim();
-    if (rws_owner.length() == 0 || rws_owner.equalsIgnoreCase(F("not set"))) {
+    bool using_self_owner = false;
+    if (rws_owner.length() == 0 || rws_owner.equalsIgnoreCase(F("not set")))
+    {
         rws_owner = String(robonomics->getSs58Address());
+        using_self_owner = true;
     }
     String datalog_data;
-    formatRobonomicsDatalogString(data, datalog_data);
-    if (datalog_data.length() == 0) {
-        debug_outln_error(F("[Datalog] WARNING: data string is empty (no sensor data, encrypt failed, or record too large)"));
+    const DatalogFormatStatus format_status = formatRobonomicsDatalogString(data, datalog_data);
+    if (
+        format_status == DATALOG_FORMAT_PAYLOAD_EMPTY ||
+        format_status == DATALOG_FORMAT_ENCRYPTION_FAILED ||
+        format_status == DATALOG_FORMAT_PAYLOAD_TOO_LARGE)
+    {
+        logDatalogLocalFailure(datalogFormatFailureReason(format_status));
         is_ok = false;
         return;
     }
     debug_outln_verbose(F("[Datalog] Sending: "), datalog_data);
     debug_outln_verbose(F("[Datalog] RWS owner: "), rws_owner);
     debug_outln_verbose(F("[Datalog] Node: "), robonomics_public_node);
-    const char* res = robonomics->sendRWSDatalogRecord(datalog_data.c_str(), rws_owner.c_str());
+    logDatalogAttempt(datalog_data.length(), datalogEncoding(format_status), using_self_owner);
+    const char *res = robonomics->sendRWSDatalogRecord(datalog_data.c_str(), rws_owner.c_str());
     const String res_s = String(res ? res : "");
     const bool lib_level_error = (res_s == "error");
     const bool json_error_object = (res_s.startsWith("{") && (res_s.indexOf("\"code\"") >= 0 || res_s.indexOf("\"message\"") >= 0));
     is_ok = (!lib_level_error && !json_error_object);
-    if (is_ok) {
+    if (is_ok)
+    {
+        logDatalogSuccess(res_s.length());
         debug_outln_verbose(F("[Datalog] OK, result: "), res_s);
-    } else {
-        debug_outln_error(F("[Datalog] FAILED"));
+    }
+    else
+    {
+        int rpc_code = 0;
+        String rpc_message = F("unknown");
+        const bool parsed_rpc_error = parseRpcError(res_s, rpc_code, rpc_message);
+        logDatalogFailure(
+            lib_level_error ? String(F("client_error")) : String(F("rpc_error")),
+            parsed_rpc_error ? rpc_code : 0,
+            parsed_rpc_error ? rpc_message : datalogToken(res_s),
+            res_s.length());
         debug_outln_verbose(F("[Datalog] Error response: "), res_s);
     }
 }

--- a/apis/robonomics_http_api.cpp
+++ b/apis/robonomics_http_api.cpp
@@ -5,23 +5,76 @@
 #include "../config_manager/config_helpers.h"
 #include <WiFi.h>
 
-void RobonomicsHTTPAPI::setup() {
+namespace
+{
+
+	void logConnectivityAttempt(uint32_t seq)
+	{
+		Serial.print(F("[CONNECTIVITY] attempt channel=sensors-connectivity seq="));
+		Serial.println(seq);
+	}
+
+	void logConnectivitySuccess(uint32_t seq, const String &host, int code)
+	{
+		Serial.print(F("[CONNECTIVITY] success channel=sensors-connectivity seq="));
+		Serial.print(seq);
+		Serial.print(F(" host="));
+		Serial.print(host);
+		Serial.print(F(" code="));
+		Serial.println(code);
+	}
+
+	void logConnectivityFailure(uint32_t seq, const String &reason)
+	{
+		Serial.print(F("[CONNECTIVITY] failed channel=sensors-connectivity seq="));
+		Serial.print(seq);
+		Serial.print(F(" reason="));
+		Serial.println(reason);
+	}
+
+	void logConnectivityFailure(uint32_t seq, const String &reason, const String &host, int code, size_t response_len = 0)
+	{
+		Serial.print(F("[CONNECTIVITY] failed channel=sensors-connectivity seq="));
+		Serial.print(seq);
+		Serial.print(F(" reason="));
+		Serial.print(reason);
+		if (host.length() > 0)
+		{
+			Serial.print(F(" host="));
+			Serial.print(host);
+		}
+		Serial.print(F(" code="));
+		Serial.print(code);
+		if (response_len > 0)
+		{
+			Serial.print(F(" response_len="));
+			Serial.print(response_len);
+		}
+		Serial.println();
+	}
+
+} // namespace
+
+void RobonomicsHTTPAPI::setup()
+{
 	api_name = "Robonomics Map";
-    _client = new WiFiClient();
-    esp_chipid = get_chipid();
-    donated_by = cfg::donated_by;
-    rws_owner = cfg::rws_owner;
+	_client = new WiFiClient();
+	esp_chipid = get_chipid();
+	donated_by = cfg::donated_by;
+	rws_owner = cfg::rws_owner;
 	current_reg = cfg::current_reg;
 	connectivity_host_override = String(cfg::robonomics_connectivity_host);
 	connectivity_host_override.trim();
 	connectivity_hosts_pool = String(cfg::robonomics_connectivity_hosts);
 	connectivity_hosts_pool.trim();
 	timeout = getConfigUintValue("sending_intervall_ms");
-	debug_outln_info(F("Robonomics HTTP API is ready with sending interval (sec): "), String(timeout/1000));
+	debug_outln_info(F("Robonomics HTTP API is ready with sending interval (sec): "), String(timeout / 1000));
 }
 
-int RobonomicsHTTPAPI::parseHostPool(const String& pool, String* out_hosts, int max_hosts) {
-	if (!out_hosts || max_hosts <= 0) return 0;
+int RobonomicsHTTPAPI::parseHostPool(const String &pool, String *out_hosts, int max_hosts)
+{
+	if (!out_hosts || max_hosts <= 0)
+		return 0;
 	int count = 0;
 	String s = pool;
 	s.replace("\r", "\n");
@@ -30,34 +83,48 @@ int RobonomicsHTTPAPI::parseHostPool(const String& pool, String* out_hosts, int 
 	s.trim();
 
 	int start = 0;
-	while (start < (int)s.length() && count < max_hosts) {
+	while (start < (int)s.length() && count < max_hosts)
+	{
 		int end = s.indexOf('\n', start);
-		if (end < 0) end = s.length();
+		if (end < 0)
+			end = s.length();
 		String item = s.substring(start, end);
 		item.trim();
-		if (item.startsWith("http://")) item.remove(0, 7);
-		if (item.startsWith("https://")) item.remove(0, 8);
+		if (item.startsWith("http://"))
+			item.remove(0, 7);
+		if (item.startsWith("https://"))
+			item.remove(0, 8);
 		int slash = item.indexOf('/');
-		if (slash >= 0) item = item.substring(0, slash);
+		if (slash >= 0)
+			item = item.substring(0, slash);
 		item.trim();
 
-		if (item.length() > 0 && item != "http" && item != "https") {
+		if (item.length() > 0 && item != "http" && item != "https")
+		{
 			bool dup = false;
-			for (int i = 0; i < count; i++) {
-				if (out_hosts[i] == item) { dup = true; break; }
+			for (int i = 0; i < count; i++)
+			{
+				if (out_hosts[i] == item)
+				{
+					dup = true;
+					break;
+				}
 			}
-			if (!dup) out_hosts[count++] = item;
+			if (!dup)
+				out_hosts[count++] = item;
 		}
 		start = end + 1;
 	}
 	return count;
 }
 
-int RobonomicsHTTPAPI::chooseRobonomicsServerFromPool(const String& pool) {
+int RobonomicsHTTPAPI::chooseRobonomicsServerFromPool(const String &pool)
+{
 	const int kMaxHosts = 8;
 	String hosts[kMaxHosts];
 	const int host_count = parseHostPool(pool, hosts, kMaxHosts);
-	if (host_count <= 0) return 255;
+	if (host_count <= 0)
+		return 255;
 
 	HTTPClient _http;
 	int best_idx = 255;
@@ -65,27 +132,33 @@ int RobonomicsHTTPAPI::chooseRobonomicsServerFromPool(const String& pool) {
 	int result = 0;
 	String s_url = FPSTR(URL_ROBONOMICS);
 
-	for (int i = 0; i < host_count; i++) {
-		if (WiFi.status() != WL_CONNECTED) break;
-		const String& s_Host = hosts[i];
+	for (int i = 0; i < host_count; i++)
+	{
+		if (WiFi.status() != WL_CONNECTED)
+			break;
+		const String &s_Host = hosts[i];
 		_http.setReuse(false);
-		if (_http.begin(*_client, s_Host, PORT_ROBONOMICS, s_url)) {
-			const char * headerKeys[] = {"sensors-count", "on-server"} ;
+		if (_http.begin(*_client, s_Host, PORT_ROBONOMICS, s_url))
+		{
+			const char *headerKeys[] = {"sensors-count", "on-server"};
 			const size_t numberOfHeaders = 2;
 			_http.collectHeaders(headerKeys, numberOfHeaders);
 			_http.addHeader("Sensor-id", robonomics->getSs58Address());
 
 			result = _http.GET();
-			if (result >= HTTP_CODE_OK && result <= HTTP_CODE_ALREADY_REPORTED) {
+			if (result >= HTTP_CODE_OK && result <= HTTP_CODE_ALREADY_REPORTED)
+			{
 				String header = _http.header("sensors-count");
 				String on_server = _http.header("on-server");
 				int num = atoi(header.c_str());
-				if (on_server == "True") {
+				if (on_server == "True")
+				{
 					best_idx = i;
 					_http.end();
 					break;
 				}
-				if (num < min_sensors) {
+				if (num < min_sensors)
+				{
 					min_sensors = num;
 					best_idx = i;
 				}
@@ -94,20 +167,25 @@ int RobonomicsHTTPAPI::chooseRobonomicsServerFromPool(const String& pool) {
 		}
 	}
 
-	if (best_idx >= 0 && best_idx < host_count) {
+	if (best_idx >= 0 && best_idx < host_count)
+	{
 		connectivity_host_override = hosts[best_idx];
 		return best_idx;
 	}
 	return 255;
 }
 
-void RobonomicsHTTPAPI::_send(JsonDocument &data) {
-    int num_of_host;
+void RobonomicsHTTPAPI::_send(JsonDocument &data)
+{
+	int num_of_host;
 	String data_to_send;
 	map_send_seq_active = ++map_send_seq;
-	debug_outln_info(String(F("[Map#")) + String(map_send_seq_active) + F("] Send attempt"));
-	if (WiFi.status() != WL_CONNECTED) {
-		debug_outln_error(F("[Map] Skipping send: WiFi is disconnected"));
+	logConnectivityAttempt(map_send_seq_active);
+	debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] Send attempt"));
+	if (WiFi.status() != WL_CONNECTED)
+	{
+		logConnectivityFailure(map_send_seq_active, F("wifi_disconnected"));
+		debug_outln_verbose(F("[Map] Skipping send: WiFi is disconnected"));
 		is_ok = false;
 		return;
 	}
@@ -115,143 +193,181 @@ void RobonomicsHTTPAPI::_send(JsonDocument &data) {
 	// If time isn't synced yet, signing will fail and we'll spam DNS/HTTP retries.
 	// Skip Map sends until NTP time becomes available.
 	struct tm timeinfo;
-	if (!getLocalTime(&timeinfo)) {
-		debug_outln_info(F("[Map] Skipping send: time not synced yet"));
+	if (!getLocalTime(&timeinfo))
+	{
+		logConnectivityFailure(map_send_seq_active, F("time_not_synced"));
+		debug_outln_verbose(F("[Map] Skipping send: time not synced yet"));
 		is_ok = false;
 		return;
 	}
 
 	formatDataToSend(data_to_send, data);
-    debug_outln_verbose(F("[Map] Payload: "), data_to_send);
+	debug_outln_verbose(F("[Map] Payload: "), data_to_send);
 	is_ok = false;
 
 	// 1) Pinned single host
-	if (connectivity_host_override.length() > 0) {
+	if (connectivity_host_override.length() > 0)
+	{
 		POSTRequest(data_to_send, connectivity_host_override);
 		return;
 	}
 
 	// 2) Custom pool list
-	if (connectivity_hosts_pool.length() > 0) {
+	if (connectivity_hosts_pool.length() > 0)
+	{
 		const int sel = chooseRobonomicsServerFromPool(connectivity_hosts_pool);
-		if (sel != 255 && connectivity_host_override.length() > 0) {
+		if (sel != 255 && connectivity_host_override.length() > 0)
+		{
 			POSTRequest(data_to_send, connectivity_host_override);
 			return;
 		}
 		// fall back to built-in pool if selection failed
 	}
 
-    num_of_host = chooseRobonomicsServer(false);
-    if (num_of_host == 255) {
-        debug_outln_verbose(F("[Map] No regional server found, trying global..."));
-        num_of_host = chooseRobonomicsServer(true);
-    }
-    if (num_of_host != 255) {
-        POSTRequest(data_to_send, String(FPSTR(HOST_ROBONOMICS[num_of_host][0])));
-    } else {
-        debug_outln_error(F("[Map] FAILED: No server available (all hosts unreachable or returned errors)"));
-        debug_outln_info(String(F("[Map#")) + String(map_send_seq_active) + F("] selection failed"));
-    }
+	num_of_host = chooseRobonomicsServer(false);
+	if (num_of_host == 255)
+	{
+		debug_outln_verbose(F("[Map] No regional server found, trying global..."));
+		num_of_host = chooseRobonomicsServer(true);
+	}
+	if (num_of_host != 255)
+	{
+		POSTRequest(data_to_send, String(FPSTR(HOST_ROBONOMICS[num_of_host][0])));
+	}
+	else
+	{
+		logConnectivityFailure(map_send_seq_active, WiFi.status() == WL_CONNECTED ? F("no_server_available") : F("wifi_disconnected"));
+		debug_outln_verbose(F("[Map] FAILED: No server available (all hosts unreachable or returned errors)"));
+		debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] selection failed"));
+	}
 }
 
-void RobonomicsHTTPAPI::formatDataToSend(String &data_to_send, JsonDocument &data) {
+void RobonomicsHTTPAPI::formatDataToSend(String &data_to_send, JsonDocument &data)
+{
 	double last_value_GPS_lat = 0.0;
 	double last_value_GPS_lon = 0.0;
 	String datalog_data;
 	int parsed = sscanf(cfg::coords_gps, "%lf,%lf", &last_value_GPS_lat, &last_value_GPS_lon);
-	if (parsed != 2 || (last_value_GPS_lat == 0.0 && last_value_GPS_lon == 0.0)) {
+	if (parsed != 2 || (last_value_GPS_lat == 0.0 && last_value_GPS_lon == 0.0))
+	{
 		debug_outln_error(F("[Map] WARNING: GPS coordinates missing or invalid, raw value: "));
 		debug_outln_verbose(F("[Map] coords_gps = "), String(cfg::coords_gps));
-	} else {
+	}
+	else
+	{
 		debug_outln_verbose(F("[Map] GPS lat="), String(last_value_GPS_lat, 6));
 		debug_outln_verbose(F("[Map] GPS lon="), String(last_value_GPS_lon, 6));
 	}
-	formatRobonomicsString(data, datalog_data);
-	if (datalog_data.length() == 0) {
+	formatRobonomicsString(data, datalog_data, F("connectivity"));
+	if (datalog_data.length() == 0)
+	{
 		debug_outln_error(F("[Map] WARNING: sensor data string is empty (all sharing disabled or no sensor data?)"));
 	}
-    String signature;
+	String signature;
 	addTimeAndSign(datalog_data, signature, robonomics);
-	if (signature.length() == 0) {
+	if (signature.length() == 0)
+	{
 		debug_outln_error(F("[Map] WARNING: signature is empty (time not synced or signing failed)"));
 	}
-    data_to_send = F("{\"robonomics_address\": \"");
-    data_to_send += robonomics->getSs58Address();
-    data_to_send += "\", \"donated_by\": \"";
-    data_to_send += donated_by;
-    data_to_send += "\", \"owner\": \"";
-    data_to_send += rws_owner;
-    data_to_send += "\", \"device_model\": \"";
-    data_to_send += DEVICE_MODEL;
-    data_to_send += "\", \"signature\": \"";
-    data_to_send += signature;
-    data_to_send += "\", \"GPS_lat\": \"";
-    data_to_send += String(last_value_GPS_lat, 6);
-    data_to_send += "\", \"GPS_lon\": \"";
-    data_to_send += String(last_value_GPS_lon, 6);
-    data_to_send += "\", \"sensordatavalues\": \"";
-    data_to_send += datalog_data;
-    data_to_send += "\"}";
+	data_to_send = F("{\"robonomics_address\": \"");
+	data_to_send += robonomics->getSs58Address();
+	data_to_send += "\", \"donated_by\": \"";
+	data_to_send += donated_by;
+	data_to_send += "\", \"owner\": \"";
+	data_to_send += rws_owner;
+	data_to_send += "\", \"device_model\": \"";
+	data_to_send += DEVICE_MODEL;
+	data_to_send += "\", \"signature\": \"";
+	data_to_send += signature;
+	data_to_send += "\", \"GPS_lat\": \"";
+	data_to_send += String(last_value_GPS_lat, 6);
+	data_to_send += "\", \"GPS_lon\": \"";
+	data_to_send += String(last_value_GPS_lon, 6);
+	data_to_send += "\", \"sensordatavalues\": \"";
+	data_to_send += datalog_data;
+	data_to_send += "\"}";
 }
 
-void RobonomicsHTTPAPI::POSTRequest(const String& data, const String& host) {
+void RobonomicsHTTPAPI::POSTRequest(const String &data, const String &host)
+{
 	HTTPClient _http;
 	String SOFTWARE_VERSION(SOFTWARE_VERSION_STR);
-    int result = 0;
-	if (WiFi.status() != WL_CONNECTED) {
-		debug_outln_error(F("[Map] POST skipped: WiFi disconnected"));
-		debug_outln_info(String(F("[Map#")) + String(map_send_seq_active) + F("] skipped: wifi disconnected"));
+	int result = 0;
+	if (WiFi.status() != WL_CONNECTED)
+	{
+		logConnectivityFailure(map_send_seq_active, F("wifi_disconnected"));
+		debug_outln_verbose(F("[Map] POST skipped: WiFi disconnected"));
+		debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] skipped: wifi disconnected"));
 		return;
 	}
-    const String& s_Host = host;
+	const String &s_Host = host;
 	String s_url(FPSTR(URL_ROBONOMICS));
-	debug_outln_info(String(F("[Map#")) + String(map_send_seq_active) + F("] POST to ") + s_Host + ":" + String(PORT_ROBONOMICS) + s_url);
-    _http.setTimeout(20 * 1000);
+	debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] POST to ") + s_Host + ":" + String(PORT_ROBONOMICS) + s_url);
+	_http.setTimeout(20 * 1000);
 	_http.setUserAgent(SOFTWARE_VERSION + '/' + esp_chipid);
-    _http.setReuse(false);
-    if (_http.begin(*_client, s_Host, PORT_ROBONOMICS, s_url)) {
-        _http.addHeader(F("Content-Type"), "application/json");
+	_http.setReuse(false);
+	if (_http.begin(*_client, s_Host, PORT_ROBONOMICS, s_url))
+	{
+		_http.addHeader(F("Content-Type"), "application/json");
 		_http.addHeader(F("X-Sensor"), String(F(SENSOR_BASENAME)) + esp_chipid);
-        result = _http.POST(data);
-        if (result >= HTTP_CODE_OK && result <= HTTP_CODE_ALREADY_REPORTED) {
-			debug_outln_info(String(F("[Map#")) + String(map_send_seq_active) + F("] OK, POST succeeded -> ") + s_Host);
+		result = _http.POST(data);
+		if (result >= HTTP_CODE_OK && result <= HTTP_CODE_ALREADY_REPORTED)
+		{
+			logConnectivitySuccess(map_send_seq_active, s_Host, result);
+			debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] OK, POST succeeded -> ") + s_Host);
 			is_ok = true;
-		} else if (result >= HTTP_CODE_BAD_REQUEST) {
-			debug_outln_error(F("[Map] FAILED: server returned HTTP error"));
+		}
+		else if (result >= HTTP_CODE_BAD_REQUEST)
+		{
+			String response_body = _http.getString();
+			logConnectivityFailure(map_send_seq_active, F("http_error"), s_Host, result, response_body.length());
+			debug_outln_verbose(F("[Map] FAILED: server returned HTTP error"));
 			debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] HTTP code: ") + String(result));
-			debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] Response body: ") + _http.getString());
-		} else {
-			debug_outln_error(F("[Map] FAILED: HTTP error (connection/timeout)"));
+			debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] Response body: ") + response_body);
+		}
+		else
+		{
+			logConnectivityFailure(map_send_seq_active, F("http_connection_error"), s_Host, result);
+			debug_outln_verbose(F("[Map] FAILED: HTTP error (connection/timeout)"));
 			debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] Error code: ") + String(result));
 			debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] Details: ") + HTTPClient::errorToString(result));
 		}
-        _http.end();
-    } else {
-		debug_outln_error(F("[Map] FAILED: could not begin HTTP connection"));
+		_http.end();
+	}
+	else
+	{
+		logConnectivityFailure(map_send_seq_active, F("http_begin_failed"), s_Host, result);
+		debug_outln_verbose(F("[Map] FAILED: could not begin HTTP connection"));
 		debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] Host: ") + s_Host);
 	}
 }
 
-int RobonomicsHTTPAPI::chooseRobonomicsServer(bool onlyGlobal) {
+int RobonomicsHTTPAPI::chooseRobonomicsServer(bool onlyGlobal)
+{
 	HTTPClient _http;
 	int num_of_robonomics_host = 255;
 	int min_sensors = 255;
 	int result = 0;
 	String s_url = FPSTR(URL_ROBONOMICS);
 	int numRobonomicsHosts = sizeof(HOST_ROBONOMICS) / sizeof(HOST_ROBONOMICS[0]);
-	debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] selecting server: ")
-		+ String(numRobonomicsHosts) + " hosts, region=" + current_reg.c_str() + (onlyGlobal ? " (global only)" : ""));
+	debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] selecting server: ") + String(numRobonomicsHosts) + " hosts, region=" + current_reg.c_str() + (onlyGlobal ? " (global only)" : ""));
 
-	for (int i = 0; i < numRobonomicsHosts; i++) {
-		if (WiFi.status() != WL_CONNECTED) {
-			debug_outln_error(F("[Map] Stop server selection: WiFi disconnected"));
+	for (int i = 0; i < numRobonomicsHosts; i++)
+	{
+		if (WiFi.status() != WL_CONNECTED)
+		{
+			debug_outln_verbose(F("[Map] Stop server selection: WiFi disconnected"));
 			break;
 		}
-		if (onlyGlobal) {
-			if (strcmp(HOST_ROBONOMICS[i][1], INTL_REGION_GLOBAL) != 0) {
+		if (onlyGlobal)
+		{
+			if (strcmp(HOST_ROBONOMICS[i][1], INTL_REGION_GLOBAL) != 0)
+			{
 				continue;
 			}
-		} else if (strcmp(current_reg.c_str(), HOST_ROBONOMICS[i][1]) != 0) {
+		}
+		else if (strcmp(current_reg.c_str(), HOST_ROBONOMICS[i][1]) != 0)
+		{
 			continue;
 		}
 		String s_Host = FPSTR(HOST_ROBONOMICS[i][0]);
@@ -260,51 +376,59 @@ int RobonomicsHTTPAPI::chooseRobonomicsServer(bool onlyGlobal) {
 		// Must not reuse TCP across different hosts — end() can keep the socket open
 		// ("tcp keep open for reuse") and the next begin() then talks to the wrong server.
 		_http.setReuse(false);
-		if (_http.begin(*_client, s_Host, PORT_ROBONOMICS, s_url)) {
-			const char * headerKeys[] = {"sensors-count", "on-server"} ;
+		if (_http.begin(*_client, s_Host, PORT_ROBONOMICS, s_url))
+		{
+			const char *headerKeys[] = {"sensors-count", "on-server"};
 			const size_t numberOfHeaders = 2;
 			_http.collectHeaders(headerKeys, numberOfHeaders);
 			_http.addHeader("Sensor-id", robonomics->getSs58Address());
 
 			result = _http.GET();
 
-			if (result >= HTTP_CODE_OK && result <= HTTP_CODE_ALREADY_REPORTED) {
+			if (result >= HTTP_CODE_OK && result <= HTTP_CODE_ALREADY_REPORTED)
+			{
 				String header = _http.header("sensors-count");
 				String on_server = _http.header("on-server");
 				int num = atoi(header.c_str());
-				debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] OK from ")
-					+ s_Host + " sensors=" + header + " on_server=" + on_server);
-				if (on_server == "True") {
+				debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] OK from ") + s_Host + " sensors=" + header + " on_server=" + on_server);
+				if (on_server == "True")
+				{
 					num_of_robonomics_host = i;
 					_http.end();
 					break;
 				}
-				if (num < min_sensors) {
+				if (num < min_sensors)
+				{
 					min_sensors = num;
 					num_of_robonomics_host = i;
 				}
-			} else if (result >= HTTP_CODE_BAD_REQUEST) {
-				debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] server error from ")
-					+ s_Host + " HTTP " + String(result));
+			}
+			else if (result >= HTTP_CODE_BAD_REQUEST)
+			{
+				debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] server error from ") + s_Host + " HTTP " + String(result));
 				debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] response: ") + _http.getString());
-			} else {
-				debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] connection error to ")
-					+ s_Host + " code=" + String(result) + " " + HTTPClient::errorToString(result));
+			}
+			else
+			{
+				debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] connection error to ") + s_Host + " code=" + String(result) + " " + HTTPClient::errorToString(result));
 			}
 			_http.end();
-
-		} else {
-			debug_outln_error(F("[Map] Cannot connect to host"));
+		}
+		else
+		{
+			debug_outln_verbose(F("[Map] Cannot connect to host"));
 			debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] host: ") + s_Host);
 		}
 	}
-	if (num_of_robonomics_host < numRobonomicsHosts) {
-		debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] selected server: ")
-			+ String(FPSTR(HOST_ROBONOMICS[num_of_robonomics_host][0])));
-	} else {
+	if (num_of_robonomics_host < numRobonomicsHosts)
+	{
+		debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] selected server: ") + String(FPSTR(HOST_ROBONOMICS[num_of_robonomics_host][0])));
+	}
+	else
+	{
 		// Not a hard failure by itself: caller may retry with global-only mode or proceed with other logic.
 		debug_outln_verbose(String(F("[Map#")) + String(map_send_seq_active) + F("] no suitable server found in this selection pass"));
 	}
-	
+
 	return num_of_robonomics_host;
 }

--- a/apis/robonomics_http_api.cpp
+++ b/apis/robonomics_http_api.cpp
@@ -201,7 +201,13 @@ void RobonomicsHTTPAPI::_send(JsonDocument &data)
 		return;
 	}
 
-	formatDataToSend(data_to_send, data);
+	if (!formatDataToSend(data_to_send, data))
+	{
+		logConnectivityFailure(map_send_seq_active, F("encryption_failed"));
+		debug_outln_error(F("[Map] Payload encryption failed; send aborted"));
+		is_ok = false;
+		return;
+	}
 	debug_outln_verbose(F("[Map] Payload: "), data_to_send);
 	is_ok = false;
 
@@ -242,7 +248,7 @@ void RobonomicsHTTPAPI::_send(JsonDocument &data)
 	}
 }
 
-void RobonomicsHTTPAPI::formatDataToSend(String &data_to_send, JsonDocument &data)
+bool RobonomicsHTTPAPI::formatDataToSend(String &data_to_send, JsonDocument &data)
 {
 	double last_value_GPS_lat = 0.0;
 	double last_value_GPS_lon = 0.0;
@@ -258,7 +264,11 @@ void RobonomicsHTTPAPI::formatDataToSend(String &data_to_send, JsonDocument &dat
 		debug_outln_verbose(F("[Map] GPS lat="), String(last_value_GPS_lat, 6));
 		debug_outln_verbose(F("[Map] GPS lon="), String(last_value_GPS_lon, 6));
 	}
-	formatRobonomicsString(data, datalog_data, F("connectivity"));
+	if (!formatRobonomicsString(data, datalog_data, F("connectivity")))
+	{
+		data_to_send = "";
+		return false;
+	}
 	if (datalog_data.length() == 0)
 	{
 		debug_outln_error(F("[Map] WARNING: sensor data string is empty (all sharing disabled or no sensor data?)"));
@@ -286,6 +296,7 @@ void RobonomicsHTTPAPI::formatDataToSend(String &data_to_send, JsonDocument &dat
 	data_to_send += "\", \"sensordatavalues\": \"";
 	data_to_send += datalog_data;
 	data_to_send += "\"}";
+	return true;
 }
 
 void RobonomicsHTTPAPI::POSTRequest(const String &data, const String &host)

--- a/apis/robonomics_http_api.cpp
+++ b/apis/robonomics_http_api.cpp
@@ -264,7 +264,7 @@ bool RobonomicsHTTPAPI::formatDataToSend(String &data_to_send, JsonDocument &dat
 		debug_outln_verbose(F("[Map] GPS lat="), String(last_value_GPS_lat, 6));
 		debug_outln_verbose(F("[Map] GPS lon="), String(last_value_GPS_lon, 6));
 	}
-	if (!formatRobonomicsString(data, datalog_data, F("connectivity")))
+	if (!formatRobonomicsString(data, datalog_data, F("sensors-connectivity")))
 	{
 		data_to_send = "";
 		return false;

--- a/apis/robonomics_http_api.h
+++ b/apis/robonomics_http_api.h
@@ -35,7 +35,7 @@ private:
     int chooseRobonomicsServer(bool onlyGlobal);
     int chooseRobonomicsServerFromPool(const String& pool);
     static int parseHostPool(const String& pool, String* out_hosts, int max_hosts);
-    void formatDataToSend(String &data_to_send, JsonDocument &data);
+    bool formatDataToSend(String &data_to_send, JsonDocument &data);
 };
 
 #endif  // __ROBONOMICS_API_H__

--- a/config_manager/config_helpers.cpp
+++ b/config_manager/config_helpers.cpp
@@ -239,6 +239,7 @@ bool writeConfig() {
 
 	if (json.overflowed()) {
 		debug_outln_error(F("Config JSON overflow while saving; increase JSON_BUFFER_SIZE"));
+		logSubsystemError(F("config"), F("json_overflow_save"));
 		return false;
 	}
 
@@ -249,6 +250,7 @@ bool writeConfig() {
 	File configFile = SPIFFS.open(F("/config.json.new"), "w");
 	if (!configFile) {
 		debug_outln_error(F("failed to open config file for writing"));
+		logSubsystemError(F("config"), F("open_write_failed"), String(F("path=/config.json")));
 		return false;
 	}
 	serializeJson(json, configFile);
@@ -381,6 +383,7 @@ void readConfig(bool oldconfig) {
 		}
 
 		debug_outln_error(F("failed to open config file."));
+		logSubsystemError(F("config"), F("open_read_failed"), String(F("path=")) + cfgName);
 		return;
 	}
 
@@ -471,6 +474,7 @@ void readConfig(bool oldconfig) {
 		}
 	} else {
 		debug_outln_error(F("failed to load json config"));
+		logSubsystemError(F("config"), F("json_parse_failed"), String(F("path=")) + cfgName);
 
 		if (!oldconfig) {
 			return readConfig(true /* oldconfig */);
@@ -499,6 +503,7 @@ void init_config() {
 
 	if (!spiffs_begin_ok) {
 		debug_outln_error(F("failed to mount FS"));
+		logSubsystemError(F("config"), F("fs_mount_failed"));
 		return;
 	}
 	readConfig();

--- a/display/screens/display_common.cpp
+++ b/display/screens/display_common.cpp
@@ -9,6 +9,7 @@
 #include "../display_modes.h"
 #include "../../defines.h"
 #include "../../config_manager/config_defaults.h"
+#include "../../utils.h"
 
 static bool epd_initialized = false;
 static DisplayMode epd_current_mode = DisplayMode::FULL; // Track current mode to avoid unnecessary re-init
@@ -221,6 +222,7 @@ bool epdDisplay(DisplayMode mode, UBYTE *Image) {
 
     if (!ok) {
         Serial.println(F("[EPD] Display stuck detected — recovering and retrying with FULL refresh"));
+        logSubsystemError(F("display"), F("epd_stuck"), String(F("action=recover_full_refresh mode=")) + String(static_cast<int>(mode)));
         epdRecoverFromStuck();
         epdInit(DisplayMode::FULL);
         EPD_4IN2_V2_Display_Fast(Image);

--- a/leds/leds_controller_insight.cpp
+++ b/leds/leds_controller_insight.cpp
@@ -118,7 +118,7 @@ void LedControllerInsight::process() {
 
             // Periodic summary to correlate with "LEDs stuck OFF" reports.
             if ((now_ms - mutex_diag_window_start_ms) >= mutex_diag_window_ms) {
-                debug_outln_info(F("[LED][DIAG] mutex window"),
+                debug_outln_verbose(F("[LED][DIAG] mutex window"),
                     String(mutex_diag_window_ms / 1000) + F("s fails=") + String(mutex_diag_fails_in_window) +
                     F(" ok=") + String(mutex_diag_success_in_window) +
                     F(" streak=") + String(mutex_diag_fail_streak));
@@ -155,7 +155,7 @@ void LedControllerInsight::process() {
         mutex_diag_success_in_window++;
         mutex_diag_fail_streak = 0;
         if ((now_ms - mutex_diag_window_start_ms) >= mutex_diag_window_ms) {
-            debug_outln_info(F("[LED][DIAG] mutex window"),
+            debug_outln_verbose(F("[LED][DIAG] mutex window"),
                 String(mutex_diag_window_ms / 1000) + F("s fails=") + String(mutex_diag_fails_in_window) +
                 F(" ok=") + String(mutex_diag_success_in_window) +
                 F(" streak=") + String(mutex_diag_fail_streak));

--- a/platformio_build_metadata.py
+++ b/platformio_build_metadata.py
@@ -71,12 +71,9 @@ else:
 
 firmware_channel = "testing" if testing_channel else "stable"
 env["ALTRUIST_ARTIFACT_CHANNEL"] = "testing" if testing_channel else "stable"
-testing_release_log_level = testing_channel and build_profile == "release"
 
 if testing_channel:
     defines.append("ALTRUIST_CHANNEL_TESTING")
-if testing_release_log_level:
-    defines.append(("ALTRUIST_FORCE_LOG_LEVEL", 3))
 
 configured_health_telemetry = _read_optional_boolean_env(
     "ALTRUIST_HEALTH_TELEMETRY"
@@ -111,9 +108,5 @@ print(f"  branch: {git_branch or 'detached/unknown'}")
 print(f"  firmware channel: {firmware_channel}")
 print(f"  profile: {build_profile}")
 print(f"  health telemetry: {'enabled' if health_telemetry else 'disabled'}")
-print(
-    "  testing release log floor: "
-    f"{'ALTRUIST_FORCE_LOG_LEVEL=3' if testing_release_log_level else 'not applied'}"
-)
 print(f"  commit: {build_commit[:7].lower() if build_commit else 'unknown'}")
 print(f"  commit source: {commit_source}")

--- a/platformio_build_metadata.py
+++ b/platformio_build_metadata.py
@@ -71,9 +71,12 @@ else:
 
 firmware_channel = "testing" if testing_channel else "stable"
 env["ALTRUIST_ARTIFACT_CHANNEL"] = "testing" if testing_channel else "stable"
+testing_release_log_level = testing_channel and build_profile == "release"
 
 if testing_channel:
     defines.append("ALTRUIST_CHANNEL_TESTING")
+if testing_release_log_level:
+    defines.append(("ALTRUIST_FORCE_LOG_LEVEL", 3))
 
 configured_health_telemetry = _read_optional_boolean_env(
     "ALTRUIST_HEALTH_TELEMETRY"
@@ -108,5 +111,9 @@ print(f"  branch: {git_branch or 'detached/unknown'}")
 print(f"  firmware channel: {firmware_channel}")
 print(f"  profile: {build_profile}")
 print(f"  health telemetry: {'enabled' if health_telemetry else 'disabled'}")
+print(
+    "  testing release log floor: "
+    f"{'ALTRUIST_FORCE_LOG_LEVEL=3' if testing_release_log_level else 'not applied'}"
+)
 print(f"  commit: {build_commit[:7].lower() if build_commit else 'unknown'}")
 print(f"  commit source: {commit_source}")

--- a/sd_card/sd_card.cpp
+++ b/sd_card/sd_card.cpp
@@ -84,6 +84,7 @@ bool SDCard::begin() {
     SDLockGuard lock;
     if (!lock.ok()) {
         debug_outln_info(F("[SDCardLogger] Failed to acquire SD mutex in begin()"));
+        logSubsystemError(F("sd"), F("mutex_timeout"), String(F("op=begin")));
         g_sd_lock_busy++;
         return false;
     }
@@ -99,12 +100,14 @@ bool SDCard::begin() {
 bool SDCard::_beginSD(SPIClass &spi) {
     if (!SD.begin(SPI_CS_PIN, spi, 40000000)) {
         debug_outln_info(F("Card Mount Failed"));
+        logSubsystemError(F("sd"), F("mount_failed"));
         return false;
     }
     uint8_t cardType = SD.cardType();
 
     if (cardType == CARD_NONE) {
         debug_outln_info(F("No SD card attached"));
+        logSubsystemError(F("sd"), F("card_missing"));
         return false;
     }
 
@@ -119,6 +122,7 @@ bool SDCard::writeTextFile(const String& fullPath, const String& content) {
     SDLockGuard lock;
     if (!lock.ok()) {
         debug_outln_info(F("[SDCardLogger] Failed to acquire SD mutex in writeTextFile()"));
+        logSubsystemError(F("sd"), F("mutex_timeout"), String(F("op=write_text")));
         g_sd_lock_busy++;
         return false;
     }
@@ -128,6 +132,7 @@ bool SDCard::writeTextFile(const String& fullPath, const String& content) {
         if (!SD.exists(folder)) {
             if (!SD.mkdir(folder)) {
                 debug_outln_info(F("[SDCardLogger] Failed to create folder for text file: "), folder);
+                logSubsystemError(F("sd"), F("mkdir_failed"), String(F("op=write_text path=")) + folder);
                 return false;
             }
         }
@@ -136,12 +141,14 @@ bool SDCard::writeTextFile(const String& fullPath, const String& content) {
     File file = SD.open(fullPath, FILE_WRITE);
     if (!file) {
         debug_outln_info(F("[SDCardLogger] Failed to open text file for write: "), fullPath);
+        logSubsystemError(F("sd"), F("open_write_failed"), String(F("path=")) + fullPath);
         return false;
     }
     size_t written = file.print(content);
     file.close();
     if (written != content.length()) {
         debug_outln_info(F("[SDCardLogger] Short write when writing text file: "), fullPath);
+        logSubsystemError(F("sd"), F("short_write"), String(F("op=write_text path=")) + fullPath);
         return false;
     }
     return true;
@@ -151,6 +158,7 @@ bool SDCard::appendTextFile(const String& fullPath, const String& content) {
     SDLockGuard lock;
     if (!lock.ok()) {
         debug_outln_info(F("[SDCardLogger] Failed to acquire SD mutex in appendTextFile()"));
+        logSubsystemError(F("sd"), F("mutex_timeout"), String(F("op=append_text")));
         g_sd_lock_busy++;
         return false;
     }
@@ -160,6 +168,7 @@ bool SDCard::appendTextFile(const String& fullPath, const String& content) {
         if (!SD.exists(folder)) {
             if (!SD.mkdir(folder)) {
                 debug_outln_info(F("[SDCardLogger] Failed to create folder for append: "), folder);
+                logSubsystemError(F("sd"), F("mkdir_failed"), String(F("op=append_text path=")) + folder);
                 return false;
             }
         }
@@ -168,12 +177,14 @@ bool SDCard::appendTextFile(const String& fullPath, const String& content) {
     File file = SD.open(fullPath, FILE_APPEND);
     if (!file) {
         debug_outln_info(F("[SDCardLogger] Failed to open text file for append: "), fullPath);
+        logSubsystemError(F("sd"), F("open_append_failed"), String(F("path=")) + fullPath);
         return false;
     }
     size_t written = file.print(content);
     file.close();
     if (written != content.length()) {
         debug_outln_info(F("[SDCardLogger] Short write when appending text file: "), fullPath);
+        logSubsystemError(F("sd"), F("short_write"), String(F("op=append_text path=")) + fullPath);
         return false;
     }
     return true;
@@ -183,6 +194,7 @@ void SDCard::refreshCache() {
     SDLockGuard lock;
     if (!lock.ok()) {
         debug_outln_info(F("[SDCardLogger] Failed to acquire SD mutex in refreshCache()"));
+        logSubsystemError(F("sd"), F("mutex_timeout"), String(F("op=refresh_cache")));
         g_sd_lock_busy++;
         return;
     }
@@ -194,12 +206,14 @@ void SDCard::refreshCache() {
             debug_outln_verbose(F("[SDCardLogger] Root folder created"));
         } else {
             debug_outln_info("[SDCardLogger] mkdir failed");
+            logSubsystemError(F("sd"), F("mkdir_failed"), String(F("op=refresh_cache path=")) + ROOT_FOLDER);
         }
     }
 
     File root = SD.open(ROOT_FOLDER);
     if (!root || !root.isDirectory()) {
         debug_outln_info(F("[SDCardLogger] Root dir error"));
+        logSubsystemError(F("sd"), F("root_open_failed"), String(F("path=")) + ROOT_FOLDER);
         return;
     }
 
@@ -277,6 +291,7 @@ void SDCard::_logCSVRow(const String& sensorName, const String& header, const St
     SDLockGuard lock;
     if (!lock.ok()) {
         debug_outln_info(F("[SDCardLogger] Failed to acquire SD mutex in _logCSVRow()"));
+        logSubsystemError(F("sd"), F("mutex_timeout"), String(F("op=log_csv sensor=")) + sensorName);
         g_sd_lock_busy++;
         g_sd_csv_write_fail++;
         return;
@@ -288,6 +303,7 @@ void SDCard::_logCSVRow(const String& sensorName, const String& header, const St
             debug_outln_verbose(F("[SDCardLogger] folder created: "), folder);
         } else {
             debug_outln_info(F("[SDCardLogger] folder not created: "), folder);
+            logSubsystemError(F("sd"), F("mkdir_failed"), String(F("op=log_csv path=")) + folder + F(" sensor=") + sensorName);
             return;
         }
     }
@@ -299,6 +315,7 @@ void SDCard::_logCSVRow(const String& sensorName, const String& header, const St
     File file = SD.open(fullPath, FILE_APPEND);
     if (!file) {
         debug_outln_info(F("[SDCardLogger] Failed to open file: "), fullPath);
+        logSubsystemError(F("sd"), F("open_append_failed"), String(F("op=log_csv path=")) + fullPath + F(" sensor=") + sensorName);
         g_sd_csv_write_fail++;
         return;
     }
@@ -313,6 +330,7 @@ void SDCard::_logCSVRow(const String& sensorName, const String& header, const St
             debug_outln_verbose(F("[SDCardLogger] Header writed: "), header);
         } else {
             debug_outln_info(F("Can't write header "));
+            logSubsystemError(F("sd"), F("csv_header_write_failed"), String(F("path=")) + fullPath + F(" sensor=") + sensorName);
         }
     }
 
@@ -322,6 +340,7 @@ void SDCard::_logCSVRow(const String& sensorName, const String& header, const St
         g_sd_csv_write_ok++;
     } else {
         debug_outln_info(F("[SDCardLogger] Can't write data: "));
+        logSubsystemError(F("sd"), F("csv_data_write_failed"), String(F("path=")) + fullPath + F(" sensor=") + sensorName);
         incrementSDWriteError();
         g_sd_csv_write_fail++;
     }
@@ -337,6 +356,7 @@ bool readSensorDataFromCSV(LineData &result, const char* sensor_name, const char
         if (msSince(last_lock_timeout_log_ms) > 3000UL) {
             last_lock_timeout_log_ms = millis();
             debug_outln_info(F("[SD] CSV read lock timeout ms"), String(lock_timeout_ms));
+            logSubsystemError(F("sd"), F("csv_read_lock_timeout"), String(F("timeout_ms=")) + String(lock_timeout_ms));
         }
         result.count = 0;
         result.values = nullptr;

--- a/sensors/radsens_sensor.cpp
+++ b/sensors/radsens_sensor.cpp
@@ -28,7 +28,7 @@ void RadSensSensor::_fetch(JsonDocument &data) {
         return;
     }
 	last_value_gc = radSens.getRadIntensyDynamic();
-    debug_outln_info(F("radiation "), last_value_gc);
+    debug_outln_verbose(F("radiation "), String(last_value_gc));
     addValueToJSON(data, F("radiation"), last_value_gc, INTL_RADIATION, F("µR/h"));
 #if defined(ALTRUIST_BUILD_DEBUG)
     serializeJson(data, Serial);

--- a/sensors/sensor_factory.h
+++ b/sensors/sensor_factory.h
@@ -19,8 +19,8 @@
 #endif
 
 String supported_sensor_names[] = {
-  BME_SENSOR_NAME,
 #if defined(ALTRUIST_URBAN)
+  BME_SENSOR_NAME,
   SDS_SENSOR_NAME,
   I2S_NOISE_SENSOR_NAME,
 #if !defined(ALTRUIST_URBAN_C3_LITE)
@@ -39,8 +39,10 @@ String supported_sensor_names[] = {
 Sensor* createSensor(const String &sensorType, unsigned long sending_timeout) {
   if (sensorType == SDS_SENSOR_NAME) {
     return new SDS011Sensor(sending_timeout);
+#if defined(ALTRUIST_URBAN)
   } else if (sensorType == BME_SENSOR_NAME) {
     return new BMX280Sensor(sending_timeout);
+#endif
   } else if (sensorType == I2S_NOISE_SENSOR_NAME) {
     return new I2SNoiseSensor(sending_timeout);
   } else if (sensorType == RADSENS_SENSOR_NAME) {

--- a/utils.cpp
+++ b/utils.cpp
@@ -423,20 +423,20 @@ void initESPTemperatureSensor() {
 			
 			esp_err_t ret = temperature_sensor_install(&temp_sensor_config, &temp_sensor_handle);
 			if (ret != ESP_OK) {
-				Serial.printf("[URBAN][Temp] Failed to install temperature sensor: %s\n", esp_err_to_name(ret));
+				Serial.printf("[ESP][Temp] Failed to install temperature sensor: %s\n", esp_err_to_name(ret));
 				return;
 			}
 			
 			ret = temperature_sensor_enable(temp_sensor_handle);
 			if (ret != ESP_OK) {
-				Serial.printf("[URBAN][Temp] Failed to enable temperature sensor: %s\n", esp_err_to_name(ret));
+				Serial.printf("[ESP][Temp] Failed to enable temperature sensor: %s\n", esp_err_to_name(ret));
 				temperature_sensor_uninstall(temp_sensor_handle);
 				temp_sensor_handle = NULL;
 				return;
 			}
 			
 			temp_sensor_initialized = true;
-			Serial.println(F("[URBAN][Temp] ESP32-C6 temperature sensor initialized"));
+			Serial.println(F("[ESP][Temp] ESP32-C6 temperature sensor initialized"));
 		#endif
 	#endif
 }

--- a/utils.cpp
+++ b/utils.cpp
@@ -343,6 +343,37 @@ void debug_outln_info_bool(const __FlashStringHelper* text, const bool option) {
 
 #undef debug_level_check
 
+void logSubsystemEvent(const __FlashStringHelper* level, const __FlashStringHelper* subsystem, const __FlashStringHelper* reason) {
+	logSubsystemEvent(level, subsystem, reason, String());
+}
+
+void logSubsystemEvent(
+	const __FlashStringHelper* level,
+	const __FlashStringHelper* subsystem,
+	const __FlashStringHelper* reason,
+	const String& details
+) {
+	Serial.print(F("[SUBSYSTEM] "));
+	Serial.print(level);
+	Serial.print(F(" subsystem="));
+	Serial.print(subsystem);
+	Serial.print(F(" reason="));
+	Serial.print(reason);
+	if (details.length() > 0) {
+		Serial.print(' ');
+		Serial.print(details);
+	}
+	Serial.println();
+}
+
+void logSubsystemError(const __FlashStringHelper* subsystem, const __FlashStringHelper* reason) {
+	logSubsystemEvent(F("error"), subsystem, reason);
+}
+
+void logSubsystemError(const __FlashStringHelper* subsystem, const __FlashStringHelper* reason, const String& details) {
+	logSubsystemEvent(F("error"), subsystem, reason, details);
+}
+
 /*****************************************************************
  * helper to see if a given string is numeric                    *
  *****************************************************************/

--- a/utils.cpp
+++ b/utils.cpp
@@ -519,6 +519,20 @@ void logMetrics() {
 	Serial.print(F(" sensor_errors="));
 	Serial.print(system_metrics.err_sensor);
 	Serial.print(F(" sd_errors="));
-	Serial.println(system_metrics.err_sd_write);
+	Serial.print(system_metrics.err_sd_write);
+	Serial.print(F(" reset_reason="));
+	Serial.print(system_metrics.reset_reason);
+	Serial.print(F(" reset_code="));
+	Serial.print(system_metrics.reset_reason_code);
+	Serial.print(F(" crash_valid="));
+	Serial.print(system_metrics.crash_context_valid ? 1 : 0);
+	Serial.print(F(" prev_uptime="));
+	Serial.print(system_metrics.prev_uptime_sec);
+	Serial.print(F(" prev_heap="));
+	Serial.print(system_metrics.prev_free_heap);
+	Serial.print(F(" last_section_id="));
+	Serial.print(system_metrics.last_section_id);
+	Serial.print(F(" last_section="));
+	Serial.println(system_metrics.last_section);
 #endif
 }

--- a/utils.h
+++ b/utils.h
@@ -173,6 +173,10 @@ extern void debug_outln_info(const __FlashStringHelper* text, const String& opti
 extern void debug_outln_info(const __FlashStringHelper* text, float value);
 extern void debug_outln_verbose(const __FlashStringHelper* text, const String& option);
 extern void debug_outln_info_bool(const __FlashStringHelper* text, const bool option);
+extern void logSubsystemEvent(const __FlashStringHelper* level, const __FlashStringHelper* subsystem, const __FlashStringHelper* reason);
+extern void logSubsystemEvent(const __FlashStringHelper* level, const __FlashStringHelper* subsystem, const __FlashStringHelper* reason, const String& details);
+extern void logSubsystemError(const __FlashStringHelper* subsystem, const __FlashStringHelper* reason);
+extern void logSubsystemError(const __FlashStringHelper* subsystem, const __FlashStringHelper* reason, const String& details);
 
 
 extern bool isNumeric(const String& str);

--- a/utils.h
+++ b/utils.h
@@ -94,6 +94,13 @@ struct device_status_t {
 struct metrics_t {
 	unsigned long boot_counter = 0;
 	unsigned long uptime_sec = 0;
+	int reset_reason_code = 0;
+	char reset_reason[32] = "unknown";
+	bool crash_context_valid = false;
+	unsigned long prev_uptime_sec = 0;
+	unsigned long prev_free_heap = 0;
+	unsigned int last_section_id = 0;
+	char last_section[24] = "unknown";
 	unsigned long tx_counter = 0;
 	time_t last_telemetry_timestamp = 0;
 	unsigned long err_wifi_reconnects = 0;

--- a/wifi_manager.cpp
+++ b/wifi_manager.cpp
@@ -110,6 +110,7 @@ uint8_t wifiScanInto(struct_wifiInfo* out, uint8_t max_out) {
 	const int8_t scanReturnCode = WiFi.scanNetworks(false /* sync */, true /* hidden */);
 	if (scanReturnCode < 0) {
 		debug_outln_error(F("WiFi scan failed"));
+		logSubsystemError(F("wifi"), F("scan_failed"), String(F("code=")) + String(scanReturnCode));
 		return 0;
 	}
 	uint8_t count = 0;
@@ -291,6 +292,13 @@ bool wifiStaRuntimeRecovery(bool deep_radio_off) {
 		debug_outln_info(F("[WiFi] Periodic STA recovery (link not ready)"));
 	}
 	debug_outln_info(F("[WiFi] status="), String((int)WiFi.status()) + F(" ip=") + WiFi.localIP().toString());
+	logSubsystemEvent(
+		F("event"),
+		F("wifi"),
+		F("sta_recovery"),
+		String(F("mode=")) + (do_deep ? F("deep") : F("soft")) + F(" status=") + String((int)WiFi.status()) +
+			F(" ip=") + WiFi.localIP().toString()
+	);
 
 	if (do_deep) {
 		// Deep recovery: force a clean wifi state transition, then re-issue begin().
@@ -469,6 +477,7 @@ void wifiRequestPortalExit(void) {
 bool wifiFinishCaptivePortalSaveAndRestart(void) {
 	if (!writeConfig()) {
 		debug_outln_error(F("[WiFi] Captive portal: failed to save config.json"));
+		logSubsystemError(F("wifi"), F("portal_config_save_failed"));
 		return false;
 	}
 	wifiRequestPortalExit();
@@ -580,6 +589,7 @@ void wifiConfig(SensorWebServer &webserver) {
 #endif
 		if (millis() - start_setup_time > 15 * 60 * 1000) {
 			debug_outln_error(F("WiFi config timeout, restarting..."));
+			logSubsystemError(F("wifi"), F("config_timeout"));
 			esp_restart();
 		}
 		if (s_portal_exit_requested) {
@@ -766,7 +776,7 @@ bool wifiApplyImprovCredentials(const String& ssid, const String& password) {
 		debug_outln_info(F("[IMPROV] Connected, IP: "), WiFi.localIP().toString());
 	} else {
 		debug_outln_error(F("[IMPROV] Failed to connect"));
+		logSubsystemError(F("wifi"), F("improv_connect_failed"), String(F("status=")) + String((int)WiFi.status()));
 	}
 	return connected;
 }
-


### PR DESCRIPTION
This PR adds a stable UART diagnostics contract for production tester runs, while keeping verbose development logs behind Debug builds.

The main goal is to let `altruist-tester` reliably validate devices during long runs, including boot/reset context, health telemetry, payload formatting, datalog sends, sensors-connectivity uploads, and subsystem errors.

### What Changed

- Added stable machine-readable UART events:
  - `[BOOT]` with reset reason, boot counter, crash context, previous uptime/heap, and last section.
  - `[HEALTH]` with uptime, boot counter, heap, RSSI, tx/errors counters, and reset context.
  - `[PAYLOAD]` with channel, encoding, encryption state, payload length, and optional plain sample.
  - `[DATALOG]` attempt/success/failed events for Robonomics datalog sends.
  - `[CONNECTIVITY]` attempt/success/failed events for sensors-connectivity uploads.
  - `[SUBSYSTEM]` events for OTA, Wi-Fi, SD, config, display, sensor/API failures.

- Kept release logs focused for tester runs:
  - stable tester contract lines are emitted directly to `Serial`;
  - verbose transport details, signatures, raw HTTP responses, and heavy diagnostics stay behind debug logging.

- Improved datalog/connectivity behavior:
  - datalog formatting failures now fail closed and do not send plaintext fallback when encryption fails;
  - datalog attempt is emitted only before the real on-chain send;
  - every connectivity attempt now has a matching success or failed result.

- Clarified build/channel/profile behavior:
  - `stable` / `testing` identifies firmware distribution channel;
  - `release` / `debug` controls diagnostic verbosity;
  - Testing release does not force a different runtime log level;
  - Debug builds keep project logs verbose via `ALTRUIST_FORCE_LOG_LEVEL=4`.

- Preserved OTA safety:
  - OTA remains pinned to Stable artifacts;
  - Testing firmware can be flashed explicitly, but automatic OTA is disabled there to avoid silently replacing it with Stable.

- Updated documentation:
  - README now explains branches, channels, profiles, artifacts, and OTA behavior;
  - DEBUGGING.md documents the tester UART contract and the difference between project logs, framework logs, and stable tester telemetry.

### Important Notes

- Release firmware now intentionally emits a small set of stable UART lines for tester compatibility. These are not controlled by `cfg::debug`.
- Plain sensor samples in `[PAYLOAD]` are included in release only when the transport payload itself is not encrypted. Debug builds may expose plain samples for encrypted payloads to aid diagnostics.